### PR TITLE
feat: department stats pages with GPA, enrollment trends, and course treemap (#782)

### DIFF
--- a/generation/aggregate.py
+++ b/generation/aggregate.py
@@ -204,6 +204,8 @@ def aggregate_subject_stats(course_ref_to_course: dict[Course.Reference, Course]
                     "total_courses": 0,
                     "total_grades_given": GradeData.empty(),
                     "total_detected_requisites": 0,
+                    "grades_by_term": {},
+                    "courses": [],
                 }
 
             stats = subject_stats[subject]
@@ -217,8 +219,37 @@ def aggregate_subject_stats(course_ref_to_course: dict[Course.Reference, Course]
                     course.prerequisites.course_references
                 )
 
+            for term, term_data in course.term_data.items():
+                if not term_data.grade_data:
+                    continue
+                existing = stats["grades_by_term"].get(term, GradeData.empty())
+                stats["grades_by_term"][term] = existing.merge_with(
+                    term_data.grade_data
+                )
+
+            cumulative = course.cumulative_grade_data
+            stats["courses"].append(
+                {
+                    "course_reference": course.course_reference,
+                    "course_title": course.course_title,
+                    "grades_given": cumulative.total if cumulative else 0,
+                    "gpa": cumulative.gpa() if cumulative else None,
+                }
+            )
+
+    for stats in subject_stats.values():
+        for grade_data in stats["grades_by_term"].values():
+            grade_data.instructors = None
+        stats["courses"].sort(key=lambda entry: entry["grades_given"], reverse=True)
+
     for subject, stats in subject_stats.items():
-        logger.info("Subject: %s, Stats: %s", subject, stats)
+        logger.info(
+            "Subject: %s, courses: %d, grades given: %d, terms: %d",
+            subject,
+            stats["total_courses"],
+            stats["total_grades_given"].total,
+            len(stats["grades_by_term"]),
+        )
 
     return subject_stats
 

--- a/generation/aggregate.py
+++ b/generation/aggregate.py
@@ -233,7 +233,6 @@ def aggregate_subject_stats(course_ref_to_course: dict[Course.Reference, Course]
                     "course_reference": course.course_reference,
                     "course_title": course.course_title,
                     "grades_given": cumulative.total if cumulative else 0,
-                    "gpa": cumulative.gpa() if cumulative else None,
                 }
             )
 

--- a/generation/enrollment_data.py
+++ b/generation/enrollment_data.py
@@ -361,6 +361,19 @@ class GradeData(JsonSerializable):
             else self.instructors or other.instructors,
         )
 
+    def gpa(self) -> float | None:
+        if not self.total:
+            return None
+        total_points = (
+            self.a * 4
+            + self.ab * 3.5
+            + self.b * 3
+            + self.bc * 2.5
+            + self.c * 2
+            + self.d
+        )
+        return total_points / self.total
+
     @classmethod
     def from_madgrades(cls, json_data) -> "GradeData":
         return GradeData(

--- a/generation/enrollment_data.py
+++ b/generation/enrollment_data.py
@@ -361,19 +361,6 @@ class GradeData(JsonSerializable):
             else self.instructors or other.instructors,
         )
 
-    def gpa(self) -> float | None:
-        if not self.total:
-            return None
-        total_points = (
-            self.a * 4
-            + self.ab * 3.5
-            + self.b * 3
-            + self.bc * 2.5
-            + self.c * 2
-            + self.d
-        )
-        return total_points / self.total
-
     @classmethod
     def from_madgrades(cls, json_data) -> "GradeData":
         return GradeData(

--- a/messages/en.json
+++ b/messages/en.json
@@ -129,6 +129,21 @@
         "title": "Request Another Fact",
         "description": "If you have an idea for a fun fact or feature, let us know!"
       }
+    },
+    "departmentalStatistics": {
+      "title": "Departmental Statistics",
+      "description": "Dive into grade trends, enrollment, and the largest courses for each department."
+    }
+  },
+  "stats": {
+    "title": "Departmental Statistics",
+    "description": "Grade and enrollment trends for every department at UW-Madison.",
+    "subject": {
+      "description": "Grade trends, enrollment, and the largest courses in {name}.",
+      "viewCourseMap": "View Course Map",
+      "totalCourses": "Total Courses",
+      "gradesGiven": "{count} grades given",
+      "noData": "Statistics for this department haven't been generated yet. Check back soon."
     }
   },
   "course": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -129,6 +129,21 @@
         "title": "다른 사실 요청하기",
         "description": "재미있는 사실이나 기능에 대한 아이디어가 있으시면 알려주세요!"
       }
+    },
+    "departmentalStatistics": {
+      "title": "todo: departmentalStatistics.title",
+      "description": "todo: departmentalStatistics.description"
+    }
+  },
+  "stats": {
+    "title": "todo: stats.title",
+    "description": "todo: stats.description",
+    "subject": {
+      "description": "todo: stats.subject.description",
+      "viewCourseMap": "todo: stats.subject.viewCourseMap",
+      "totalCourses": "todo: stats.subject.totalCourses",
+      "gradesGiven": "todo: stats.subject.gradesGiven",
+      "noData": "todo: stats.subject.noData"
     }
   },
   "course": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -131,19 +131,19 @@
       }
     },
     "departmentalStatistics": {
-      "title": "todo: departmentalStatistics.title",
-      "description": "todo: departmentalStatistics.description"
+      "title": "학과별 통계",
+      "description": "각 학과의 성적 추세, 수강 인원, 규모가 가장 큰 강의를 살펴보세요."
     }
   },
   "stats": {
-    "title": "todo: stats.title",
-    "description": "todo: stats.description",
+    "title": "학과별 통계",
+    "description": "UW-Madison 모든 학과의 성적 및 수강 인원 추세.",
     "subject": {
-      "description": "todo: stats.subject.description",
-      "viewCourseMap": "todo: stats.subject.viewCourseMap",
-      "totalCourses": "todo: stats.subject.totalCourses",
-      "gradesGiven": "todo: stats.subject.gradesGiven",
-      "noData": "todo: stats.subject.noData"
+      "description": "{name}의 성적 추세, 수강 인원, 규모가 가장 큰 강의.",
+      "viewCourseMap": "코스 맵 보기",
+      "totalCourses": "전체 강의",
+      "gradesGiven": "부여된 성적 {count}개",
+      "noData": "이 학과의 통계는 아직 생성되지 않았습니다. 곧 다시 확인해 주세요."
     }
   },
   "course": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -129,6 +129,21 @@
         "title": "请求其他事实",
         "description": "如果您有任何有趣事实或功能的想法，请告诉我们！"
       }
+    },
+    "departmentalStatistics": {
+      "title": "todo: departmentalStatistics.title",
+      "description": "todo: departmentalStatistics.description"
+    }
+  },
+  "stats": {
+    "title": "todo: stats.title",
+    "description": "todo: stats.description",
+    "subject": {
+      "description": "todo: stats.subject.description",
+      "viewCourseMap": "todo: stats.subject.viewCourseMap",
+      "totalCourses": "todo: stats.subject.totalCourses",
+      "gradesGiven": "todo: stats.subject.gradesGiven",
+      "noData": "todo: stats.subject.noData"
     }
   },
   "course": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -131,19 +131,19 @@
       }
     },
     "departmentalStatistics": {
-      "title": "todo: departmentalStatistics.title",
-      "description": "todo: departmentalStatistics.description"
+      "title": "院系统计",
+      "description": "深入了解各院系的成绩趋势、选课人数以及规模最大的课程。"
     }
   },
   "stats": {
-    "title": "todo: stats.title",
-    "description": "todo: stats.description",
+    "title": "院系统计",
+    "description": "UW-Madison 各院系的成绩与选课人数趋势。",
     "subject": {
-      "description": "todo: stats.subject.description",
-      "viewCourseMap": "todo: stats.subject.viewCourseMap",
-      "totalCourses": "todo: stats.subject.totalCourses",
-      "gradesGiven": "todo: stats.subject.gradesGiven",
-      "noData": "todo: stats.subject.noData"
+      "description": "{name}的成绩趋势、选课人数以及规模最大的课程。",
+      "viewCourseMap": "查看课程地图",
+      "totalCourses": "总课程数",
+      "gradesGiven": "已评 {count} 个成绩",
+      "noData": "该院系的统计数据尚未生成，请稍后再来查看。"
     }
   },
   "course": {

--- a/project.inlang/.gitignore
+++ b/project.inlang/.gitignore
@@ -1,1 +1,2 @@
 cache
+project_id

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,10 +1,34 @@
 import { env } from "$env/dynamic/public";
+import { error } from "@sveltejs/kit";
 
 const PUBLIC_API_URL = env.PUBLIC_API_URL;
 const PUBLIC_SEARCH_API_URL = env.PUBLIC_SEARCH_API_URL;
 
 export async function apiFetch(path: string): Promise<Response> {
   return await fetch(`${PUBLIC_API_URL}${path}`);
+}
+
+// takes the load-provided fetch so it works during SSR
+export async function fetchSubjects(
+  fetch: typeof globalThis.fetch,
+): Promise<Record<string, string>> {
+  const response = await fetch(`${PUBLIC_API_URL}/subjects.json`);
+  if (!response.ok)
+    throw error(
+      response.status,
+      `Failed to fetch subjects: ${response.statusText}`,
+    );
+  return await response.json();
+}
+
+export async function getSubjectFullName(
+  fetch: typeof globalThis.fetch,
+  subject: string,
+): Promise<string> {
+  const response = await fetch(`${PUBLIC_API_URL}/subjects.json`);
+  if (!response.ok) return subject;
+  const subjects = await response.json();
+  return subjects[subject] || subject;
 }
 
 export async function getRandomCourses(): Promise<Response> {

--- a/src/lib/components/charts/course-treemap-chart.svelte
+++ b/src/lib/components/charts/course-treemap-chart.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import {
+    TreemapChart,
+    type TreemapChartOptions,
+  } from "@carbon/charts-svelte";
+  import "@carbon/charts-svelte/styles.css";
+  import type { SubjectCourseStat } from "$lib/types/subject-stats.ts";
+  import { CourseUtils } from "$lib/types/course.ts";
+  import { getCarbonTheme } from "$lib/theme.ts";
+  import { mode } from "mode-watcher";
+
+  // beyond this the smallest tiles are unlabeled slivers
+  const MAX_COURSES = 40;
+
+  interface Props {
+    courses: SubjectCourseStat[];
+  }
+
+  let { courses }: Props = $props();
+
+  function levelLabel(courseNumber: number): string {
+    return `${Math.floor(courseNumber / 100) * 100}-level`;
+  }
+
+  let data = $derived.by(() => {
+    const largest = [...courses]
+      .filter((course) => course.grades_given > 0)
+      .sort((a, b) => b.grades_given - a.grades_given)
+      .slice(0, MAX_COURSES);
+
+    const byLevel = new Map<string, { name: string; value: number }[]>();
+    for (const course of largest) {
+      const label = levelLabel(course.course_reference.course_number);
+      const children = byLevel.get(label) ?? [];
+      children.push({
+        name: CourseUtils.courseReferenceToString(course.course_reference),
+        value: course.grades_given,
+      });
+      byLevel.set(label, children);
+    }
+
+    return [...byLevel.entries()]
+      .sort(([a], [b]) => a.localeCompare(b, undefined, { numeric: true }))
+      .map(([name, children]) => ({ name, children }));
+  });
+
+  let options: TreemapChartOptions = $derived({
+    title: "Largest Courses by Grades Given",
+    height: "500px",
+    theme: getCarbonTheme(mode.current),
+  });
+</script>
+
+<TreemapChart {data} {options} />

--- a/src/lib/components/charts/course-treemap-chart.svelte
+++ b/src/lib/components/charts/course-treemap-chart.svelte
@@ -18,30 +18,30 @@
 
   let { courses }: Props = $props();
 
-  function levelLabel(courseNumber: number): string {
-    return `${Math.floor(courseNumber / 100) * 100}-level`;
+  function levelLabel(level: number): string {
+    return level === 0 ? "Below 100" : `${level}-level`;
   }
 
   let data = $derived.by(() => {
-    const largest = [...courses]
+    const largest = courses
       .filter((course) => course.grades_given > 0)
-      .sort((a, b) => b.grades_given - a.grades_given)
       .slice(0, MAX_COURSES);
 
-    const byLevel = new Map<string, { name: string; value: number }[]>();
+    const byLevel = new Map<number, { name: string; value: number }[]>();
     for (const course of largest) {
-      const label = levelLabel(course.course_reference.course_number);
-      const children = byLevel.get(label) ?? [];
+      const level =
+        Math.floor(course.course_reference.course_number / 100) * 100;
+      const children = byLevel.get(level) ?? [];
       children.push({
         name: CourseUtils.courseReferenceToString(course.course_reference),
         value: course.grades_given,
       });
-      byLevel.set(label, children);
+      byLevel.set(level, children);
     }
 
     return [...byLevel.entries()]
-      .sort(([a], [b]) => a.localeCompare(b, undefined, { numeric: true }))
-      .map(([name, children]) => ({ name, children }));
+      .sort(([a], [b]) => a - b)
+      .map(([level, children]) => ({ name: levelLabel(level), children }));
   });
 
   let options: TreemapChartOptions = $derived({

--- a/src/lib/components/charts/enrollment-over-terms-chart.svelte
+++ b/src/lib/components/charts/enrollment-over-terms-chart.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import {
+    AreaChart,
+    type AreaChartOptions,
+    type ChartTabularData,
+    ScaleTypes,
+  } from "@carbon/charts-svelte";
+  import "@carbon/charts-svelte/styles.css";
+  import type { GradeData } from "$lib/types/madgrades.ts";
+  import type { Terms } from "$lib/types/terms.ts";
+  import { getCarbonTheme } from "$lib/theme.ts";
+  import { mode } from "mode-watcher";
+
+  interface Props {
+    gradesByTerm: {
+      [key: string]: GradeData;
+    };
+    terms: Terms;
+  }
+
+  let { gradesByTerm, terms }: Props = $props();
+
+  let data: ChartTabularData = $derived(
+    Object.entries(gradesByTerm)
+      .sort(([a], [b]) => Number(a) - Number(b))
+      .map(([termCode, gradeData]) => ({
+        group: "Enrollment",
+        term: terms[termCode] ?? termCode,
+        value: gradeData.total,
+      })),
+  );
+
+  let options: AreaChartOptions = $derived({
+    title: "Enrollment Over Terms",
+    axes: {
+      left: {
+        title: "Students Graded",
+        scaleType: ScaleTypes.LINEAR,
+        mapsTo: "value",
+      },
+      bottom: {
+        title: "Term",
+        scaleType: ScaleTypes.LABELS,
+        mapsTo: "term",
+      },
+    },
+    curve: "curveMonotoneX",
+    legend: {
+      enabled: false,
+    },
+    height: "400px",
+    theme: getCarbonTheme(mode.current),
+  });
+</script>
+
+<AreaChart {data} {options} />

--- a/src/lib/components/charts/grade-data-horizontal-bar-chart.svelte
+++ b/src/lib/components/charts/grade-data-horizontal-bar-chart.svelte
@@ -4,21 +4,22 @@
     type BarChartOptions,
     BarChartSimple,
     type ChartTabularData,
-    MeterChart, type MeterChartOptions,
+    MeterChart,
+    type MeterChartOptions,
     ScaleTypes,
   } from "@carbon/charts-svelte";
   import "@carbon/charts-svelte/styles.css";
   import { getCarbonTheme } from "$lib/theme.ts";
   import { mode } from "mode-watcher";
   import type { TermData } from "$lib/types/course.ts";
-  import type {Terms} from "$lib/types/terms.ts";
+  import type { Terms } from "$lib/types/terms.ts";
   interface Props {
     cumulative: GradeData;
-    termData: {
+    termData?: {
       [key: string]: TermData;
     };
     term?: string | null;
-    terms: Terms
+    terms: Terms;
   }
 
   let { cumulative, termData, term, terms }: Props = $props();
@@ -26,14 +27,16 @@
   let hasAvailableTermData = $derived.by(() => {
     if (!term || !termData) return false;
     return Object.keys(termData).length > 0 && termData[term] != null;
-  })
+  });
 
   let currentTermName = $derived(
     hasAvailableTermData ? terms[term!] : "Cumulative",
   );
 
   let gradeData: GradeData = $derived(
-    hasAvailableTermData ? termData[term!].grade_data ?? cumulative : cumulative,
+    hasAvailableTermData
+      ? (termData![term!].grade_data ?? cumulative)
+      : cumulative,
   );
 
   let data: ChartTabularData = $derived(
@@ -74,15 +77,15 @@
   );
 
   const colorScale = {
-    A:   "#2ECC71",
-    AB:  "#27AE60",
-    B:   "#F1C40F",
-    BC:  "#F39C12",
-    C:   "#E67E22",
-    D:   "#E74C3C",
-    F:   "#C0392B",
+    A: "#2ECC71",
+    AB: "#27AE60",
+    B: "#F1C40F",
+    BC: "#F39C12",
+    C: "#E67E22",
+    D: "#E74C3C",
+    F: "#C0392B",
     Other: "#6F6F6F",
-  }
+  };
 
   let options: BarChartOptions = $derived({
     title: "Grade Distribution",
@@ -103,19 +106,19 @@
     },
     theme: getCarbonTheme(mode.current),
     color: {
-     scale: colorScale
-    }
+      scale: colorScale,
+    },
   });
 
-  let meterData = $derived(data.toReversed())
+  let meterData = $derived(data.toReversed());
 
-  let meterOptions : MeterChartOptions = $derived({
-    height: '30px',
+  let meterOptions: MeterChartOptions = $derived({
+    height: "30px",
     meter: {
       proportional: {
         total: gradeData.total,
         totalFormatter: (value: number) => ``,
-      }
+      },
     },
     toolbar: {
       enabled: false,
@@ -125,20 +128,19 @@
       enabled: false,
     },
     color: {
-      scale: colorScale
+      scale: colorScale,
     },
     tooltip: {
-      valueFormatter: (value: number) => `${(value * 100 / gradeData.total).toFixed(2)}%`
-    }
-  })
-
-
+      valueFormatter: (value: number) =>
+        `${((value * 100) / gradeData.total).toFixed(2)}%`,
+    },
+  });
 </script>
 
 <div class="h-full">
   <BarChartSimple {data} {options} />
   <MeterChart data={meterData} options={meterOptions} />
-  <p class="text-xs text-muted-foreground text-center mt-4">
+  <p class="text-muted-foreground mt-4 text-center text-xs">
     {currentTermName} Grade Distribution
   </p>
 </div>

--- a/src/lib/components/subject-card-grid.svelte
+++ b/src/lib/components/subject-card-grid.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import {
+    Card,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+  } from "$lib/components/ui/card/index.js";
+  import { localizeHref } from "$lib/paraglide/runtime";
+
+  interface Props {
+    subjects: [string, string][];
+  }
+
+  let { subjects }: Props = $props();
+
+  let sorted = $derived(
+    [...subjects].sort(([, a], [, b]) => a.localeCompare(b)),
+  );
+</script>
+
+<div
+  class="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
+>
+  {#each sorted as [code, name]}
+    <a href={localizeHref(`/stats/${code}`)} class="flex h-full w-full">
+      <Card class="flex h-full w-full flex-col">
+        <CardHeader>
+          <CardTitle class="truncate">{name}</CardTitle>
+          <CardDescription class="truncate font-bold">
+            {code}
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    </a>
+  {/each}
+</div>

--- a/src/lib/types/subject-stats.ts
+++ b/src/lib/types/subject-stats.ts
@@ -5,7 +5,6 @@ export type SubjectCourseStat = {
   course_reference: CourseReference;
   course_title: string;
   grades_given: number;
-  gpa: number | null;
 };
 
 export type SubjectStats = {

--- a/src/lib/types/subject-stats.ts
+++ b/src/lib/types/subject-stats.ts
@@ -1,0 +1,18 @@
+import type { GradeData } from "$lib/types/madgrades.ts";
+import type { CourseReference } from "$lib/types/course.ts";
+
+export type SubjectCourseStat = {
+  course_reference: CourseReference;
+  course_title: string;
+  grades_given: number;
+  gpa: number | null;
+};
+
+export type SubjectStats = {
+  total_courses: number;
+  total_grades_given: GradeData;
+  total_detected_requisites: number;
+  // absent from stats JSON generated before these fields existed
+  grades_by_term?: { [term: string]: GradeData };
+  courses?: SubjectCourseStat[];
+};

--- a/src/routes/explorer/+page.svelte
+++ b/src/routes/explorer/+page.svelte
@@ -39,7 +39,9 @@
   </PageHeader>
   <section class="my-4">
     <div class="my-8">
-      <h2 class="my-2 text-4xl font-bold">{m["explorer.frequentlyVisited.title"]()}</h2>
+      <h2 class="my-2 text-4xl font-bold">
+        {m["explorer.frequentlyVisited.title"]()}
+      </h2>
       <p class="text-muted-foreground">
         {m["explorer.frequentlyVisited.description"]()}
       </p>
@@ -60,7 +62,10 @@
           </CardDescription>
         </Card>
       </a>
-      <a href={localizeHref("/instructors/by-rating-count")} class="flex h-full">
+      <a
+        href={localizeHref("/instructors/by-rating-count")}
+        class="flex h-full"
+      >
         <Card>
           <CardHeader class="pb-3">
             <CardTitle class="flex truncate">
@@ -104,25 +109,32 @@
       </a>
     </div>
   </section>
-  <!--    <section>-->
-  <!--        <div class="my-8">-->
-  <!--            <h2 class="text-4xl font-bold my-2">Departmental Statistics</h2>-->
-  <!--            <p class="text-muted-foreground">-->
-  <!--            </p>-->
-  <!--        </div>-->
-  <!--        <div class="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">-->
-  <!--            {#each subjects as [code, name]}-->
-  <!--                <a href="/stats/{code}" class="flex h-full w-full">-->
-  <!--                    <Card class="flex flex-col h-full w-full">-->
-  <!--                        <CardHeader>-->
-  <!--                            <CardTitle class="truncate">{name}</CardTitle>-->
-  <!--                            <CardDescription class="font-bold truncate">{code}</CardDescription>-->
-  <!--                        </CardHeader>-->
-  <!--                    </Card>-->
-  <!--                </a>-->
-  <!--            {/each}-->
-  <!--        </div>-->
-  <!--    </section>-->
+  <section class="my-4">
+    <div class="my-8">
+      <h2 class="my-2 text-4xl font-bold">
+        {m["explorer.departmentalStatistics.title"]()}
+      </h2>
+      <p class="text-muted-foreground">
+        {m["explorer.departmentalStatistics.description"]()}
+      </p>
+    </div>
+    <div
+      class="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
+    >
+      {#each subjects as [code, name]}
+        <a href={localizeHref(`/stats/${code}`)} class="flex h-full w-full">
+          <Card class="flex h-full w-full flex-col">
+            <CardHeader>
+              <CardTitle class="truncate">{name}</CardTitle>
+              <CardDescription class="truncate font-bold">
+                {code}
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        </a>
+      {/each}
+    </div>
+  </section>
   <!--    <section class="text-sm my-8 text-center text-muted-foreground block">-->
   <!--        <span>-->
   <!--            You've got to be bored to scroll all the way here. Here's a cookie.-->

--- a/src/routes/explorer/+page.svelte
+++ b/src/routes/explorer/+page.svelte
@@ -6,6 +6,7 @@
     PageHeaderHeading,
   } from "$lib/components/page-header";
   import Search from "$lib/components/search.svelte";
+  import SubjectCardGrid from "$lib/components/subject-card-grid.svelte";
   import {
     Card,
     CardDescription,
@@ -118,22 +119,7 @@
         {m["explorer.departmentalStatistics.description"]()}
       </p>
     </div>
-    <div
-      class="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
-    >
-      {#each subjects as [code, name]}
-        <a href={localizeHref(`/stats/${code}`)} class="flex h-full w-full">
-          <Card class="flex h-full w-full flex-col">
-            <CardHeader>
-              <CardTitle class="truncate">{name}</CardTitle>
-              <CardDescription class="truncate font-bold">
-                {code}
-              </CardDescription>
-            </CardHeader>
-          </Card>
-        </a>
-      {/each}
-    </div>
+    <SubjectCardGrid {subjects} />
   </section>
   <!--    <section class="text-sm my-8 text-center text-muted-foreground block">-->
   <!--        <span>-->

--- a/src/routes/explorer/+page.ts
+++ b/src/routes/explorer/+page.ts
@@ -1,14 +1,9 @@
-import { env } from "$env/dynamic/public";
+import { fetchSubjects } from "$lib/api.ts";
 import { generateOgImageUrl } from "$lib/seo/og-image";
 
-const { PUBLIC_API_URL } = env;
-
 export const load = async ({ fetch }) => {
-  const subjectResponse = await fetch(`${PUBLIC_API_URL}/subjects.json`);
-  if (!subjectResponse.ok)
-    throw new Error(`Failed to fetch subjects: ${subjectResponse.statusText}`);
   const subjects: [string, string][] = Object.entries(
-    await subjectResponse.json(),
+    await fetchSubjects(fetch),
   );
 
   const ogImage = generateOgImageUrl({

--- a/src/routes/explorer/[subject]/+page.ts
+++ b/src/routes/explorer/[subject]/+page.ts
@@ -1,6 +1,7 @@
 import { env } from "$env/dynamic/public";
 import { error } from "@sveltejs/kit";
 import type { ElementDefinition } from "cytoscape";
+import { getSubjectFullName } from "$lib/api.ts";
 import { generateOgImageUrl } from "$lib/seo/og-image";
 
 const { PUBLIC_API_URL } = env;
@@ -8,13 +9,7 @@ const { PUBLIC_API_URL } = env;
 export const load = async ({ params, fetch }) => {
   let subject = params.subject.toUpperCase();
 
-  // Fetch subjects to get full name
-  const subjectsResponse = await fetch(`${PUBLIC_API_URL}/subjects.json`);
-  let subjectFullName = subject;
-  if (subjectsResponse.ok) {
-    const subjects = await subjectsResponse.json();
-    subjectFullName = subjects[subject] || subject;
-  }
+  const subjectFullName = await getSubjectFullName(fetch, subject);
 
   const elementDefinitionsResponse = await fetch(
     `${PUBLIC_API_URL}/graphs/${subject}.json`,

--- a/src/routes/stats/+page.svelte
+++ b/src/routes/stats/+page.svelte
@@ -5,14 +5,8 @@
     PageHeaderDescription,
     PageHeaderHeading,
   } from "$lib/components/page-header";
-  import {
-    Card,
-    CardDescription,
-    CardHeader,
-    CardTitle,
-  } from "$lib/components/ui/card/index.js";
+  import SubjectCardGrid from "$lib/components/subject-card-grid.svelte";
   import { m } from "$lib/paraglide/messages";
-  import { localizeHref } from "$lib/paraglide/runtime";
 
   let { data } = $props();
 
@@ -27,21 +21,6 @@
     </PageHeaderDescription>
   </PageHeader>
   <section class="my-8">
-    <div
-      class="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
-    >
-      {#each subjects as [code, name]}
-        <a href={localizeHref(`/stats/${code}`)} class="flex h-full w-full">
-          <Card class="flex h-full w-full flex-col">
-            <CardHeader>
-              <CardTitle class="truncate">{name}</CardTitle>
-              <CardDescription class="truncate font-bold">
-                {code}
-              </CardDescription>
-            </CardHeader>
-          </Card>
-        </a>
-      {/each}
-    </div>
+    <SubjectCardGrid {subjects} />
   </section>
 </ContentWrapper>

--- a/src/routes/stats/+page.svelte
+++ b/src/routes/stats/+page.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import ContentWrapper from "$lib/components/content/content-wrapper.svelte";
+  import {
+    PageHeader,
+    PageHeaderDescription,
+    PageHeaderHeading,
+  } from "$lib/components/page-header";
+  import {
+    Card,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+  } from "$lib/components/ui/card/index.js";
+  import { m } from "$lib/paraglide/messages";
+  import { localizeHref } from "$lib/paraglide/runtime";
+
+  let { data } = $props();
+
+  let { subjects } = $derived(data);
+</script>
+
+<ContentWrapper>
+  <PageHeader>
+    <PageHeaderHeading>{m["stats.title"]()}</PageHeaderHeading>
+    <PageHeaderDescription class="text-muted-foreground">
+      {m["stats.description"]()}
+    </PageHeaderDescription>
+  </PageHeader>
+  <section class="my-8">
+    <div
+      class="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
+    >
+      {#each subjects as [code, name]}
+        <a href={localizeHref(`/stats/${code}`)} class="flex h-full w-full">
+          <Card class="flex h-full w-full flex-col">
+            <CardHeader>
+              <CardTitle class="truncate">{name}</CardTitle>
+              <CardDescription class="truncate font-bold">
+                {code}
+              </CardDescription>
+            </CardHeader>
+          </Card>
+        </a>
+      {/each}
+    </div>
+  </section>
+</ContentWrapper>

--- a/src/routes/stats/+page.ts
+++ b/src/routes/stats/+page.ts
@@ -1,20 +1,10 @@
-import { env } from "$env/dynamic/public";
-import { error } from "@sveltejs/kit";
+import { fetchSubjects } from "$lib/api.ts";
 import { generateOgImageUrl } from "$lib/seo/og-image";
 
-const { PUBLIC_API_URL } = env;
-
 export const load = async ({ fetch }) => {
-  const subjectsResponse = await fetch(`${PUBLIC_API_URL}/subjects.json`);
-  if (!subjectsResponse.ok)
-    throw error(
-      subjectsResponse.status,
-      `Failed to fetch subjects: ${subjectsResponse.statusText}`,
-    );
-  const subjectEntries: [string, string][] = Object.entries(
-    await subjectsResponse.json(),
+  const subjects: [string, string][] = Object.entries(
+    await fetchSubjects(fetch),
   );
-  const subjects = subjectEntries.sort(([, a], [, b]) => a.localeCompare(b));
 
   const ogImage = generateOgImageUrl({
     title: "Departmental Statistics",

--- a/src/routes/stats/+page.ts
+++ b/src/routes/stats/+page.ts
@@ -1,0 +1,30 @@
+import { env } from "$env/dynamic/public";
+import { error } from "@sveltejs/kit";
+import { generateOgImageUrl } from "$lib/seo/og-image";
+
+const { PUBLIC_API_URL } = env;
+
+export const load = async ({ fetch }) => {
+  const subjectsResponse = await fetch(`${PUBLIC_API_URL}/subjects.json`);
+  if (!subjectsResponse.ok)
+    throw error(
+      subjectsResponse.status,
+      `Failed to fetch subjects: ${subjectsResponse.statusText}`,
+    );
+  const subjectEntries: [string, string][] = Object.entries(
+    await subjectsResponse.json(),
+  );
+  const subjects = subjectEntries.sort(([, a], [, b]) => a.localeCompare(b));
+
+  const ogImage = generateOgImageUrl({
+    title: "Departmental Statistics",
+    subtitle: "UW-Madison",
+    description: "Grade and enrollment trends for every department",
+  });
+
+  return {
+    subtitle: "Statistics",
+    ogImage,
+    subjects,
+  };
+};

--- a/src/routes/stats/[subject]/+page.svelte
+++ b/src/routes/stats/[subject]/+page.svelte
@@ -35,9 +35,11 @@
 
   let { subject, subjectFullName, stats, terms } = $derived(data);
 
-  let gradesByTerm = $derived(stats.grades_by_term ?? {});
+  let gradesByTerm = $derived(stats?.grades_by_term ?? {});
   let hasTermData = $derived(Object.keys(gradesByTerm).length > 0);
-  let hasCourses = $derived((stats.courses?.length ?? 0) > 0);
+  let courses = $derived(stats?.courses ?? []);
+
+  let hasCourses = $derived(courses.some((course) => course.grades_given > 0));
 
   let latestGradeData = $derived.by(() => {
     const termCodes = Object.keys(gradesByTerm).sort(
@@ -57,19 +59,15 @@
   );
 
   let cumulativeGPA = $derived(
-    calculateGradePointAverage(stats.total_grades_given),
+    calculateGradePointAverage(stats?.total_grades_given),
   );
-  let termGPA = $derived(
-    calculateGradePointAverage(latestGradeData) ?? cumulativeGPA,
-  );
+  let termGPA = $derived(calculateGradePointAverage(latestGradeData));
   let cumulativeCompletionRate = $derived(
-    calculateCompletionRate(stats.total_grades_given),
+    calculateCompletionRate(stats?.total_grades_given),
   );
-  let termCompletionRate = $derived(
-    calculateCompletionRate(latestGradeData) ?? cumulativeCompletionRate,
-  );
-  let cumulativeARate = $derived(calculateARate(stats.total_grades_given));
-  let termARate = $derived(calculateARate(latestGradeData) ?? cumulativeARate);
+  let termCompletionRate = $derived(calculateCompletionRate(latestGradeData));
+  let cumulativeARate = $derived(calculateARate(stats?.total_grades_given));
+  let termARate = $derived(calculateARate(latestGradeData));
 </script>
 
 <ContentWrapper>
@@ -87,69 +85,77 @@
     </a>
   </PageHeader>
 
-  <section class="my-4 space-y-4">
-    <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
-      <GPADataCard {termGPA} {cumulativeGPA} />
-      <CompletionRateDataCard {termCompletionRate} {cumulativeCompletionRate} />
-      <ARateDataCard {termARate} {cumulativeARate} />
-      <Card>
-        <CardHeader
-          class="flex flex-row items-center justify-between space-y-0 pb-2"
-        >
-          <CardTitle class="text-sm font-medium">
-            {m["stats.subject.totalCourses"]()}
-          </CardTitle>
-          <BookOpen class="text-muted-foreground h-4 w-4" />
-        </CardHeader>
-        <CardContent>
-          <div class="text-2xl font-bold">
-            {stats.total_courses.toLocaleString()}
-          </div>
-          <p class="text-muted-foreground mt-0.5 text-xs">
-            {m["stats.subject.gradesGiven"]({
-              count: stats.total_grades_given.total.toLocaleString(),
-            })}
-          </p>
-        </CardContent>
-      </Card>
-    </div>
-
-    {#if hasTermData}
-      <div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
+  {#if !stats}
+    <p class="text-muted-foreground my-8 text-center">
+      {m["stats.subject.noData"]()}
+    </p>
+  {:else}
+    <section class="my-4 space-y-4">
+      <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <GPADataCard {termGPA} {cumulativeGPA} />
+        <CompletionRateDataCard
+          {termCompletionRate}
+          {cumulativeCompletionRate}
+        />
+        <ARateDataCard {termARate} {cumulativeARate} />
         <Card>
-          <CardContent class="pt-6">
-            <EnrollmentOverTermsChart {gradesByTerm} {terms} />
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent class="pt-6">
-            <GradeDataHorizontalBarChart
-              cumulative={stats.total_grades_given}
-              termData={comboTermData}
-              {terms}
-            />
+          <CardHeader
+            class="flex flex-row items-center justify-between space-y-0 pb-2"
+          >
+            <CardTitle class="text-sm font-medium">
+              {m["stats.subject.totalCourses"]()}
+            </CardTitle>
+            <BookOpen class="text-muted-foreground h-4 w-4" />
+          </CardHeader>
+          <CardContent>
+            <div class="text-2xl font-bold">
+              {stats.total_courses.toLocaleString()}
+            </div>
+            <p class="text-muted-foreground mt-0.5 text-xs">
+              {m["stats.subject.gradesGiven"]({
+                count: stats.total_grades_given.total.toLocaleString(),
+              })}
+            </p>
           </CardContent>
         </Card>
       </div>
-      <Card>
-        <CardContent class="pt-6">
-          <ComboGradeDataStackedAreaChart term_data={comboTermData} {terms} />
-        </CardContent>
-      </Card>
-    {/if}
 
-    {#if hasCourses}
-      <Card>
-        <CardContent class="pt-6">
-          <CourseTreemapChart courses={stats.courses ?? []} />
-        </CardContent>
-      </Card>
-    {/if}
+      {#if hasTermData}
+        <div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <Card>
+            <CardContent class="pt-6">
+              <EnrollmentOverTermsChart {gradesByTerm} {terms} />
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent class="pt-6">
+              <GradeDataHorizontalBarChart
+                cumulative={stats.total_grades_given}
+                {terms}
+              />
+            </CardContent>
+          </Card>
+        </div>
+        <Card>
+          <CardContent class="pt-6">
+            <ComboGradeDataStackedAreaChart term_data={comboTermData} {terms} />
+          </CardContent>
+        </Card>
+      {/if}
 
-    {#if !hasTermData && !hasCourses}
-      <p class="text-muted-foreground my-8 text-center">
-        {m["stats.subject.noData"]()}
-      </p>
-    {/if}
-  </section>
+      {#if hasCourses}
+        <Card>
+          <CardContent class="pt-6">
+            <CourseTreemapChart {courses} />
+          </CardContent>
+        </Card>
+      {/if}
+
+      {#if !hasTermData && !hasCourses}
+        <p class="text-muted-foreground my-8 text-center">
+          {m["stats.subject.noData"]()}
+        </p>
+      {/if}
+    </section>
+  {/if}
 </ContentWrapper>

--- a/src/routes/stats/[subject]/+page.svelte
+++ b/src/routes/stats/[subject]/+page.svelte
@@ -5,15 +5,151 @@
     PageHeaderDescription,
     PageHeaderHeading,
   } from "$lib/components/page-header";
+  import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+  } from "$lib/components/ui/card/index.js";
+  import {
+    ARateDataCard,
+    CompletionRateDataCard,
+    GPADataCard,
+  } from "$lib/components/data-card/index.js";
+  import ComboGradeDataStackedAreaChart from "$lib/components/charts/combo-grade-data-stacked-area-chart.svelte";
+  import CourseTreemapChart from "$lib/components/charts/course-treemap-chart.svelte";
+  import EnrollmentOverTermsChart from "$lib/components/charts/enrollment-over-terms-chart.svelte";
+  import GradeDataHorizontalBarChart from "$lib/components/charts/grade-data-horizontal-bar-chart.svelte";
+  import {
+    calculateARate,
+    calculateCompletionRate,
+    calculateGradePointAverage,
+  } from "$lib/types/madgrades.ts";
+  import type { TermData } from "$lib/types/course.ts";
+  import { BookOpen, Waypoints } from "@lucide/svelte";
+  import { buttonVariants } from "$lib/components/ui/button/index.js";
+  import { m } from "$lib/paraglide/messages";
+  import { localizeHref } from "$lib/paraglide/runtime";
+
+  let { data } = $props();
+
+  let { subject, subjectFullName, stats, terms } = $derived(data);
+
+  let gradesByTerm = $derived(stats.grades_by_term ?? {});
+  let hasTermData = $derived(Object.keys(gradesByTerm).length > 0);
+  let hasCourses = $derived((stats.courses?.length ?? 0) > 0);
+
+  let latestGradeData = $derived.by(() => {
+    const termCodes = Object.keys(gradesByTerm).sort(
+      (a, b) => Number(a) - Number(b),
+    );
+    const latest = termCodes.at(-1);
+    return latest ? gradesByTerm[latest] : null;
+  });
+
+  let comboTermData: { [key: string]: TermData } = $derived(
+    Object.fromEntries(
+      Object.entries(gradesByTerm).map(([term, gradeData]) => [
+        term,
+        { enrollment_data: null, grade_data: gradeData },
+      ]),
+    ),
+  );
+
+  let cumulativeGPA = $derived(
+    calculateGradePointAverage(stats.total_grades_given),
+  );
+  let termGPA = $derived(
+    calculateGradePointAverage(latestGradeData) ?? cumulativeGPA,
+  );
+  let cumulativeCompletionRate = $derived(
+    calculateCompletionRate(stats.total_grades_given),
+  );
+  let termCompletionRate = $derived(
+    calculateCompletionRate(latestGradeData) ?? cumulativeCompletionRate,
+  );
+  let cumulativeARate = $derived(calculateARate(stats.total_grades_given));
+  let termARate = $derived(calculateARate(latestGradeData) ?? cumulativeARate);
 </script>
 
 <ContentWrapper>
   <PageHeader>
-    <PageHeaderHeading>Coming Soon?</PageHeaderHeading>
+    <PageHeaderHeading>{subjectFullName}</PageHeaderHeading>
     <PageHeaderDescription class="text-muted-foreground">
-      Haven't had time to implement this yet, see <a
-        href="https://github.com/twangodev/uw-coursemap/issues/782">#782</a
-      >
+      {m["stats.subject.description"]({ name: subjectFullName })}
     </PageHeaderDescription>
+    <a
+      href={localizeHref(`/explorer/${subject}`)}
+      class={buttonVariants({ variant: "outline" })}
+    >
+      <Waypoints class="mr-2 size-4" />
+      {m["stats.subject.viewCourseMap"]()}
+    </a>
   </PageHeader>
+
+  <section class="my-4 space-y-4">
+    <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+      <GPADataCard {termGPA} {cumulativeGPA} />
+      <CompletionRateDataCard {termCompletionRate} {cumulativeCompletionRate} />
+      <ARateDataCard {termARate} {cumulativeARate} />
+      <Card>
+        <CardHeader
+          class="flex flex-row items-center justify-between space-y-0 pb-2"
+        >
+          <CardTitle class="text-sm font-medium">
+            {m["stats.subject.totalCourses"]()}
+          </CardTitle>
+          <BookOpen class="text-muted-foreground h-4 w-4" />
+        </CardHeader>
+        <CardContent>
+          <div class="text-2xl font-bold">
+            {stats.total_courses.toLocaleString()}
+          </div>
+          <p class="text-muted-foreground mt-0.5 text-xs">
+            {m["stats.subject.gradesGiven"]({
+              count: stats.total_grades_given.total.toLocaleString(),
+            })}
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+
+    {#if hasTermData}
+      <div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <Card>
+          <CardContent class="pt-6">
+            <EnrollmentOverTermsChart {gradesByTerm} {terms} />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent class="pt-6">
+            <GradeDataHorizontalBarChart
+              cumulative={stats.total_grades_given}
+              termData={comboTermData}
+              {terms}
+            />
+          </CardContent>
+        </Card>
+      </div>
+      <Card>
+        <CardContent class="pt-6">
+          <ComboGradeDataStackedAreaChart term_data={comboTermData} {terms} />
+        </CardContent>
+      </Card>
+    {/if}
+
+    {#if hasCourses}
+      <Card>
+        <CardContent class="pt-6">
+          <CourseTreemapChart courses={stats.courses ?? []} />
+        </CardContent>
+      </Card>
+    {/if}
+
+    {#if !hasTermData && !hasCourses}
+      <p class="text-muted-foreground my-8 text-center">
+        {m["stats.subject.noData"]()}
+      </p>
+    {/if}
+  </section>
 </ContentWrapper>

--- a/src/routes/stats/[subject]/+page.ts
+++ b/src/routes/stats/[subject]/+page.ts
@@ -1,0 +1,49 @@
+import { env } from "$env/dynamic/public";
+import { error } from "@sveltejs/kit";
+import type { SubjectStats } from "$lib/types/subject-stats.ts";
+import type { Terms } from "$lib/types/terms.ts";
+import { generateOgImageUrl } from "$lib/seo/og-image";
+
+const { PUBLIC_API_URL } = env;
+
+export const load = async ({ params, fetch }) => {
+  const subject = params.subject.toUpperCase();
+
+  const subjectsResponse = await fetch(`${PUBLIC_API_URL}/subjects.json`);
+  let subjectFullName = subject;
+  if (subjectsResponse.ok) {
+    const subjects = await subjectsResponse.json();
+    subjectFullName = subjects[subject] || subject;
+  }
+
+  const statsResponse = await fetch(`${PUBLIC_API_URL}/stats/${subject}.json`);
+  if (!statsResponse.ok)
+    throw error(
+      statsResponse.status,
+      `Failed to fetch subject statistics: ${statsResponse.statusText}`,
+    );
+  const stats: SubjectStats = await statsResponse.json();
+
+  const termsResponse = await fetch(`${PUBLIC_API_URL}/terms.json`);
+  if (!termsResponse.ok)
+    throw error(
+      termsResponse.status,
+      `Failed to fetch terms: ${termsResponse.statusText}`,
+    );
+  const terms: Terms = await termsResponse.json();
+
+  const ogImage = generateOgImageUrl({
+    title: subject,
+    subtitle: subjectFullName,
+    description: `${subjectFullName} grade and enrollment statistics at UW-Madison`,
+  });
+
+  return {
+    subtitle: `${subject} - Statistics`,
+    ogImage,
+    subject,
+    subjectFullName,
+    stats,
+    terms,
+  };
+};

--- a/src/routes/stats/[subject]/+page.ts
+++ b/src/routes/stats/[subject]/+page.ts
@@ -2,6 +2,7 @@ import { env } from "$env/dynamic/public";
 import { error } from "@sveltejs/kit";
 import type { SubjectStats } from "$lib/types/subject-stats.ts";
 import type { Terms } from "$lib/types/terms.ts";
+import { getSubjectFullName } from "$lib/api.ts";
 import { generateOgImageUrl } from "$lib/seo/og-image";
 
 const { PUBLIC_API_URL } = env;
@@ -9,22 +10,23 @@ const { PUBLIC_API_URL } = env;
 export const load = async ({ params, fetch }) => {
   const subject = params.subject.toUpperCase();
 
-  const subjectsResponse = await fetch(`${PUBLIC_API_URL}/subjects.json`);
-  let subjectFullName = subject;
-  if (subjectsResponse.ok) {
-    const subjects = await subjectsResponse.json();
-    subjectFullName = subjects[subject] || subject;
-  }
+  const [subjectFullName, statsResponse, termsResponse] = await Promise.all([
+    getSubjectFullName(fetch, subject),
+    fetch(`${PUBLIC_API_URL}/stats/${subject}.json`),
+    fetch(`${PUBLIC_API_URL}/terms.json`),
+  ]);
 
-  const statsResponse = await fetch(`${PUBLIC_API_URL}/stats/${subject}.json`);
-  if (!statsResponse.ok)
+  // a subject can exist in subjects.json before its stats file is generated
+  let stats: SubjectStats | null = null;
+  if (statsResponse.ok) {
+    stats = await statsResponse.json();
+  } else if (statsResponse.status !== 404) {
     throw error(
       statsResponse.status,
       `Failed to fetch subject statistics: ${statsResponse.statusText}`,
     );
-  const stats: SubjectStats = await statsResponse.json();
+  }
 
-  const termsResponse = await fetch(`${PUBLIC_API_URL}/terms.json`);
   if (!termsResponse.ok)
     throw error(
       termsResponse.status,


### PR DESCRIPTION
Closes #782.

Adds a stats page per department at `/stats/[subject]`, an index page at `/stats`, and brings back the department grid on the explorer page.

Each department page shows:
 - GPA, completion rate, A rate, and total courses (same cards as the course page, latest term vs historical)
 - Enrollment over terms
 - Grade distribution and grade trends over time
 - A treemap of the largest courses, grouped by level

On the data side, `aggregate_subject_stats` now writes `grades_by_term` and a per-course size list into `/stats/{SUBJECT}.json`. If the CDN still serves the old JSON shape, the page falls back to the summary cards with a note until the next generation run picks up the new fields.

<img width="1624" height="1008" alt="Screenshot 2026-08-06 at 8 16 00 AM" src="https://github.com/user-attachments/assets/5133cf40-22cb-4632-ada5-db404b591e77" />
<img width="1365" height="571" alt="Screenshot 2026-08-06 at 8 16 17 AM" src="https://github.com/user-attachments/assets/bf8de782-9d36-4911-9476-ce2bbe07b496" />
<img width="1370" height="573" alt="Screenshot 2026-08-06 at 8 16 23 AM" src="https://github.com/user-attachments/assets/3118d43c-940e-45d2-8b29-ffc4d8913e9a" />
<img width="1624" height="1008" alt="Screenshot 2026-08-06 at 8 17 44 AM" src="https://github.com/user-attachments/assets/d554fbf3-172b-436c-851f-693fe87cc3b7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added departmental statistics browsing from the Explorer.
  - Added subject statistics pages with course totals, grade distributions, term trends, GPA, completion rates, A-rate summaries, and course maps.
  - Added enrollment, grade, trend, and course visualizations.
  - Added localized statistics content in English, Korean, and Chinese.
- **Bug Fixes**
  - Improved subject loading reliability and fallback behavior when names or statistics are unavailable.
  - Added clear no-data messaging for unavailable statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->