### PR TITLE
fix(deploy): read Cloudflare account ID from variables

### DIFF
--- a/.github/workflows/svelte.yml
+++ b/.github/workflows/svelte.yml
@@ -95,7 +95,7 @@ jobs:
       - run: bun x playwright test
       - name: Deploy verified release
         env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           FIRST_DEPLOYMENT: ${{ inputs.first_deployment || false }}
         run: uv run --locked uwcourses-site deploy

--- a/web/README.md
+++ b/web/README.md
@@ -34,7 +34,7 @@ bun run preview --ip 0.0.0.0 --port 4173
 
 ## Cloudflare setup
 
-The A/B D1 database IDs are configured in `wrangler.json` as `DB_A` and `DB_B`. Set `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` as secrets in the GitHub `production` environment with Workers Scripts and D1 edit permissions. `HF_TOKEN` is optional for the public dataset.
+The A/B D1 database IDs are configured in `wrangler.json` as `DB_A` and `DB_B`. Set `CLOUDFLARE_ACCOUNT_ID` as a GitHub variable and `CLOUDFLARE_API_TOKEN` as a secret in the `production` environment. The token needs Workers Scripts and D1 edit permissions. `HF_TOKEN` is optional for the public dataset.
 
 Run the **Svelte** workflow manually with **First deployment** enabled once to create the Worker. Validate its workers.dev preview, then attach `uwcourses.com` in Cloudflare. Subsequent runs leave that option disabled.
 


### PR DESCRIPTION
Read CLOUDFLARE_ACCOUNT_ID from GitHub variables while keeping CLOUDFLARE_API_TOKEN in secrets. Update the deployment setup instructions to match. Verified the configured variable and token names and checked the diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Cloudflare deployment setup guidance to clarify configuration requirements.
  - Documented that the account ID is configured as a repository or organization variable, while the API token remains a production secret with the required permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->