### PR TITLE
perf(web): serve static JSON documents with a single D1 for queries

### DIFF
--- a/.github/workflows/svelte.yml
+++ b/.github/workflows/svelte.yml
@@ -35,7 +35,7 @@ jobs:
           python-version: "3.12"
           enable-cache: true
       - run: bun install --frozen-lockfile
-      - run: uv run --locked uwcourses-site import --limit 8
+      - run: uv run --locked uwcourses-site import
       - run: uv run --locked python -m unittest discover -s web/tests -p 'test_*.py'
       - run: bun run check
       - run: bun run test

--- a/_headers
+++ b/_headers
@@ -5,3 +5,7 @@
   X-Robots-Tag: noindex
 /*/__data.json
   X-Robots-Tag: noindex
+
+/__documents/*
+  X-Robots-Tag: noindex
+  Cache-Control: public, max-age=0, must-revalidate

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -2,9 +2,7 @@ declare global {
   namespace App {
     interface Platform {
       env: {
-        DB_A: D1Database;
-        DB_B: D1Database;
-        DATA_SLOT: string;
+        DB: D1Database;
         SITE_COMMIT?: string;
         DATA_PROJECTION?: string;
         DEPLOYED_AT?: string;

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,3 +1,5 @@
+import { withDatabaseAvailability } from "$lib/server/database-availability";
+import { isFilteredDocument } from "$lib/server/documents/storage";
 import { ZodError } from "zod";
 import { building, dev } from "$app/environment";
 import { redirect, isHttpError, type Handle } from "@sveltejs/kit";
@@ -51,7 +53,16 @@ export const handle: Handle = async ({ event, resolve }) => {
       response.headers.append("Link", alternateLinks(path, event.url.search));
     return response;
   };
+  const documentUrl = new URL(event.url);
+  documentUrl.pathname = requested?.path || path;
+  const needsDatabase =
+    (path.startsWith("/api/") && path !== "/api/status") ||
+    isFilteredDocument(documentUrl);
+  const serve =
+    !building && !dev && needsDatabase
+      ? () => withDatabaseAvailability(event.platform, render)
+      : render;
   return !building && !dev && (requested || isDocument(path))
-    ? cachedResponse(event, render)
-    : render();
+    ? cachedResponse(event, serve)
+    : serve();
 };

--- a/src/lib/api/schemas.ts
+++ b/src/lib/api/schemas.ts
@@ -209,7 +209,7 @@ export const courseDataSchema = named(
   "CourseData",
   z.object({
     course: courseSchema,
-    context: record,
+    context: record.nullable(),
     instructorTrends: z.array(record),
     following: z.array(z.object({ code: z.string(), title: z.string() })),
     projection: projectionSchema.nullable(),

--- a/src/lib/server/course-context.ts
+++ b/src/lib/server/course-context.ts
@@ -1,4 +1,10 @@
-import { aggregateTerms, cohortBenchmarks, type Benchmarks } from "$lib/grade-benchmarks";
+import { error } from "@sveltejs/kit";
+import { readAsset } from "./documents/storage";
+import {
+  aggregateTerms,
+  cohortBenchmarks,
+  type Benchmarks,
+} from "$lib/grade-benchmarks";
 import { building, dev } from "$app/environment";
 import { query } from "./data";
 import { compareCourse, type PeerCourse } from "$lib/course-context";
@@ -21,7 +27,14 @@ function index(rows: PeerCourse[]): Catalog {
     groups.set(key, group);
     courses.set(row.uid + ":" + row.term, row);
   }
-  return { groups, courses, benchmarks: new Map([...groups].map(([term, rows]) => [term, cohortBenchmarks(rows)])), histories: new Map() };
+  return {
+    groups,
+    courses,
+    benchmarks: new Map(
+      [...groups].map(([term, rows]) => [term, cohortBenchmarks(rows)]),
+    ),
+    histories: new Map(),
+  };
 }
 async function peers(
   platform: App.Platform | undefined,
@@ -53,48 +66,104 @@ async function peers(
         term: row.term,
         gpa,
         count,
-        topShare: 100 * (counts[0] + counts[1]) / count,
+        topShare: (100 * (counts[0] + counts[1])) / count,
         subjects: JSON.parse(row.subjects),
       },
     ];
   });
 }
 
-export async function courseContext(course: any, platform?: App.Platform, sharedCatalog?: Catalog) {
+export async function courseContext(
+  course: any,
+  platform?: App.Platform,
+  sharedCatalog?: Catalog,
+) {
+  if (!building && !dev) {
+    const stored = await readAsset<{ context: any }>(
+      `/__documents/contexts/${course.course_uid}.json`,
+      platform,
+    );
+    if (!stored) error(503, "Published course comparisons unavailable");
+    return stored.context;
+  }
   const term = [...course.grades].sort((a, b) =>
     b.term_id.localeCompare(a.term_id),
   )[0]?.term_id;
   if (!term) return null;
-  const catalog = sharedCatalog || await badgeCatalog(platform);
+  const catalog = sharedCatalog || (await badgeCatalog(platform));
   const current = catalog.courses.get(course.course_uid + ":" + term);
   if (!current) return null;
-  const terms = [...new Set<string>(course.grades.map((row: any) => row.term_id))].sort();
+  const terms = [
+    ...new Set<string>(course.grades.map((row: any) => row.term_id)),
+  ].sort();
   const historyKey = terms.join(",");
   let history = catalog.histories.get(historyKey);
   if (!history) {
-    const rows = aggregateTerms(terms.flatMap((term) => catalog.groups.get(term) || [])).map((row) => ({ ...row, term: "", code: "" }));
+    const rows = aggregateTerms(
+      terms.flatMap((term) => catalog.groups.get(term) || []),
+    ).map((row) => ({ ...row, term: "", code: "" }));
     history = { benchmarks: cohortBenchmarks(rows), rows };
-    if (catalog.histories.size >= 128) catalog.histories.delete(catalog.histories.keys().next().value!);
+    if (catalog.histories.size >= 128)
+      catalog.histories.delete(catalog.histories.keys().next().value!);
     catalog.histories.set(historyKey, history);
   }
-  const select = (values: Benchmarks = {}) => Object.fromEntries(["school", ...current.subjects].map((key) => [key, values[key] || null]));
-  const contextFor = (current: PeerCourse | undefined, rows: PeerCourse[]) => current ? {
-    term: current.term, gpa: current.gpa, count: current.count,
-    university: compareCourse(current, rows),
-    departments: current.subjects.map((subject) => ({ subject, comparison: compareCourse(current, rows, subject) })),
-  } : null;
+  const select = (values: Benchmarks = {}) =>
+    Object.fromEntries(
+      ["school", ...current.subjects].map((key) => [key, values[key] || null]),
+    );
+  const contextFor = (current: PeerCourse | undefined, rows: PeerCourse[]) =>
+    current
+      ? {
+          term: current.term,
+          gpa: current.gpa,
+          count: current.count,
+          university: compareCourse(current, rows),
+          departments: current.subjects.map((subject) => ({
+            subject,
+            comparison: compareCourse(current, rows, subject),
+          })),
+        }
+      : null;
   return {
-    all: contextFor(history.rows.find((row) => row.uid === course.course_uid), history.rows),
-    terms: Object.fromEntries(terms.map((term) => [term, contextFor(catalog.courses.get(course.course_uid + ":" + term), catalog.groups.get(term) || [])])),
-    benchmarks: { all: select(history.benchmarks), terms: Object.fromEntries(terms.map((term) => [term, select(catalog.benchmarks.get(term))])) },
+    all: contextFor(
+      history.rows.find((row) => row.uid === course.course_uid),
+      history.rows,
+    ),
+    terms: Object.fromEntries(
+      terms.map((term) => [
+        term,
+        contextFor(
+          catalog.courses.get(course.course_uid + ":" + term),
+          catalog.groups.get(term) || [],
+        ),
+      ]),
+    ),
+    benchmarks: {
+      all: select(history.benchmarks),
+      terms: Object.fromEntries(
+        terms.map((term) => [term, select(catalog.benchmarks.get(term))]),
+      ),
+    },
   };
 }
 
 async function badgeCatalog(platform?: App.Platform) {
-  return building || dev ? await (buildPeers ??= peers(platform).then(index)) : index(await peers(platform));
+  return building || dev
+    ? await (buildPeers ??= peers(platform).then(index))
+    : index(await peers(platform));
 }
 export async function courseContexts(courses: any[], platform?: App.Platform) {
   if (!courses.length) return new Map();
-  const catalog = await badgeCatalog(platform);
-  return new Map(await Promise.all(courses.map(async course => [course.course_uid, await courseContext(course, platform, catalog)] as const)));
+  const catalog = building || dev ? await badgeCatalog(platform) : undefined;
+  return new Map(
+    await Promise.all(
+      courses.map(
+        async (course) =>
+          [
+            course.course_uid,
+            await courseContext(course, platform, catalog),
+          ] as const,
+      ),
+    ),
+  );
 }

--- a/src/lib/server/data.ts
+++ b/src/lib/server/data.ts
@@ -1,8 +1,12 @@
+import publishedStatus from "../../../.site/status.json";
 import { database, localDatabase } from "./database";
-import { metadata, courses, instructors } from "./schema";
+import { courses, instructors } from "./schema";
 import { eq, sql as drizzleSql } from "drizzle-orm";
 import { withInstructorUrls } from "./instructor-urls";
-import { instructorRatingPrior, withInstructorRatings } from "./instructor-ratings";
+import {
+  instructorRatingPrior,
+  withInstructorRatings,
+} from "./instructor-ratings";
 import { ratingPriorWeight } from "$lib/instructor-ratings";
 import { isCourseCollection } from "$lib/course-collections";
 import { building, dev } from "$app/environment";
@@ -11,20 +15,29 @@ import { coursePreviews } from "./discovery";
 import { normalize } from "$lib/format";
 import type { Status } from "$lib/types";
 /** Existing FTS and aggregation queries retain bound parameters. */
-export async function query<T = any>(platform: App.Platform | undefined, statement: string, values: unknown[] = []): Promise<T[]> {
-  if (building || dev) return (await localDatabase()).prepare(statement).all(...values) as T[];
+export async function query<T = any>(
+  platform: App.Platform | undefined,
+  statement: string,
+  values: unknown[] = [],
+): Promise<T[]> {
+  if (building || dev)
+    return (await localDatabase()).prepare(statement).all(...values) as T[];
   // All SQL templates are internal; values remain parameters in Drizzle/D1.
   const parts = statement.split("?");
-  if (parts.length !== values.length + 1) throw new Error("SQL parameter count mismatch");
-  const chunks = parts.flatMap((part, index) => index < values.length
-    ? [drizzleSql.raw(part), drizzleSql`${values[index]}`] : [drizzleSql.raw(part)]);
-  return await database(platform).all<T>(drizzleSql.join(chunks, drizzleSql.raw(""))) as T[];
+  if (parts.length !== values.length + 1)
+    throw new Error("SQL parameter count mismatch");
+  const chunks = parts.flatMap((part, index) =>
+    index < values.length
+      ? [drizzleSql.raw(part), drizzleSql`${values[index]}`]
+      : [drizzleSql.raw(part)],
+  );
+  return (await database(platform).all<T>(
+    drizzleSql.join(chunks, drizzleSql.raw("")),
+  )) as T[];
 }
 export async function status(platform?: App.Platform): Promise<Status> {
-  const [r] = await database(platform).select({ value: metadata.value }).from(metadata).where(eq(metadata.key, "status"));
-  if (!r) error(503, "Dataset not imported");
   return {
-    ...JSON.parse(r.value),
+    ...publishedStatus,
     deployed_at: building || dev ? null : platform?.env.DEPLOYED_AT || null,
     slot: building || dev ? null : platform?.env.DATA_SLOT || null,
   };
@@ -35,7 +48,10 @@ export async function pageData(
   platform?: App.Platform,
 ): Promise<any> {
   const table = kind === "courses" ? courses : instructors;
-  const [r] = await database(platform).select({ payload: table.payload }).from(table).where(eq(table.uid, uid));
+  const [r] = await database(platform)
+    .select({ payload: table.payload })
+    .from(table)
+    .where(eq(table.uid, uid));
   if (!r)
     error(
       404,
@@ -134,10 +150,12 @@ export async function search(url: URL, platform?: App.Platform) {
     }
   }
   const ranking = url.searchParams.get("ranking");
-  if (ranking && (kind !== "course" || !isCourseCollection(ranking))) error(400, "Invalid course ranking");
+  if (ranking && (kind !== "course" || !isCourseCollection(ranking)))
+    error(400, "Invalid course ranking");
   if (ranking) where += " AND h.grade_count>=100";
   const sort = url.searchParams.get("sort");
-  const prior = kind === "instructor" ? await instructorRatingPrior(platform) : null;
+  const prior =
+    kind === "instructor" ? await instructorRatingPrior(platform) : null;
   const qualityCount = "json_extract(c.payload,'$.ratings.quality_count')";
   const adjustedQuality = `CASE WHEN ${qualityCount}>0 THEN (json_extract(c.payload,'$.ratings.quality')*${qualityCount}+${prior ?? "NULL"}*${ratingPriorWeight})/(${qualityCount}+${ratingPriorWeight}) END`;
   const order =
@@ -145,11 +163,11 @@ export async function search(url: URL, platform?: App.Platform) {
       ? `c.current DESC,${adjustedQuality} DESC,c.name`
       : ranking
         ? `h.history_gpa ${ranking === "hardest" ? "ASC" : "DESC"},h.grade_count DESC,c.code`
-      : sort === "gpa"
-        ? "CASE WHEN h.grade_count>=100 THEN 0 ELSE 1 END,CASE WHEN h.grade_count>=100 THEN h.history_gpa END DESC,c.code"
-        : expression
-          ? "min(m.score),c.code"
-          : "c.code";
+        : sort === "gpa"
+          ? "CASE WHEN h.grade_count>=100 THEN 0 ELSE 1 END,CASE WHEN h.grade_count>=100 THEN h.history_gpa END DESC,c.code"
+          : expression
+            ? "min(m.score),c.code"
+            : "c.code";
   const fields =
     kind === "course"
       ? "c.uid course_uid,c.code course_id,c.title,c.credits_min,c.credits_max,c.gpa"
@@ -166,7 +184,15 @@ export async function search(url: URL, platform?: App.Platform) {
   );
   return {
     items:
-      kind === "course" ? await coursePreviews(items, term, platform, undefined, url.searchParams.get("subject") || "school") : await withInstructorUrls(items, platform),
+      kind === "course"
+        ? await coursePreviews(
+            items,
+            term,
+            platform,
+            undefined,
+            url.searchParams.get("subject") || "school",
+          )
+        : await withInstructorUrls(items, platform),
     total: count.total,
     page,
     kind,

--- a/src/lib/server/data.ts
+++ b/src/lib/server/data.ts
@@ -39,7 +39,6 @@ export async function status(platform?: App.Platform): Promise<Status> {
   return {
     ...publishedStatus,
     deployed_at: building || dev ? null : platform?.env.DEPLOYED_AT || null,
-    slot: building || dev ? null : platform?.env.DATA_SLOT || null,
   };
 }
 export async function pageData(

--- a/src/lib/server/database-availability.ts
+++ b/src/lib/server/database-availability.ts
@@ -1,0 +1,44 @@
+import { error } from "@sveltejs/kit";
+import { inArray } from "drizzle-orm";
+import { database } from "./database";
+import { metadata } from "./schema";
+import publishedStatus from "../../../.site/status.json";
+
+/** Page documents stay available while a single D1 is replaced in place. */
+export async function withDatabaseAvailability<T>(
+  platform: App.Platform | undefined,
+  render: () => Promise<T>,
+) {
+  const check = async () => {
+    let token: string | undefined;
+    try {
+      const rows = await database(platform)
+        .select()
+        .from(metadata)
+        .where(inArray(metadata.key, ["ready", "status", "serving"]));
+      const state = Object.fromEntries(rows.map((row) => [row.key, row.value]));
+      if (
+        state.ready === "true" &&
+        /^[a-f0-9]{32}$/.test(state.serving || "") &&
+        JSON.parse(state.status).projection_id === publishedStatus.projection_id
+      )
+        token = state.serving;
+    } catch {
+      /* Missing metadata is expected while the schema is replaced. */
+    }
+    if (!token)
+      error(503, "Search and filters are updating. Please try again shortly.");
+    return token;
+  };
+  const token = await check();
+  try {
+    const response = await render();
+    // Do not return a result if an import started during its queries.
+    if ((await check()) !== token)
+      error(503, "Search was updated during this request. Please try again.");
+    return response;
+  } catch (cause) {
+    await check();
+    throw cause;
+  }
+}

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -24,7 +24,7 @@ const localClient = proxy(async (statement, params, method) => {
 }, { schema });
 export function database(platform?: App.Platform): BaseSQLiteDatabase<"async", any, typeof schema> {
   if (building || dev) return localClient;
-  const binding = platform?.env.DATA_SLOT === "b" ? platform.env.DB_B : platform?.env.DB_A;
+  const binding = platform?.env.DB;
   if (!binding) error(503, "Dataset database unavailable");
   let client = clients.get(binding);
   if (!client) { client = drizzle(binding, { schema }); clients.set(binding, client); }

--- a/src/lib/server/documents/build.ts
+++ b/src/lib/server/documents/build.ts
@@ -1,0 +1,116 @@
+import { building } from "$app/environment";
+import { error } from "@sveltejs/kit";
+import { query, status } from "$lib/server/data";
+import { instructorUrls } from "$lib/server/instructor-urls";
+import { courseContext } from "$lib/server/course-context";
+import { courseUrl } from "$lib/format";
+import { documentKind, documentSchemas } from "$lib/api/schemas";
+import { pageSeo } from "$lib/seo";
+import { loadSourceDocument } from "./index";
+import { documentAsset } from "./storage";
+import entries from "../../../../.site/entries.json";
+
+let inventory: ReturnType<typeof createInventory> | undefined;
+async function createInventory() {
+  const [courses, instructors, aliases] = await Promise.all([
+    query(undefined, "SELECT uid,code FROM courses ORDER BY code"),
+    instructorUrls(),
+    query(
+      undefined,
+      "SELECT a.alias,c.code FROM aliases a JOIN courses c ON c.uid=a.uid ORDER BY a.alias,c.code",
+    ),
+  ]);
+  const paths = [
+    "/",
+    "/search",
+    "/departments",
+    "/explorer",
+    "/explorer/all",
+    "/instructors/by-rating-count",
+    "/courses/easiest",
+    "/courses/hardest",
+    ...courses.map((c) => courseUrl(c.code)),
+    ...instructors.values(),
+    ...entries.subjects.flatMap((subject) =>
+      ["", "/catalog", "/easiest", "/hardest"]
+        .map((tail) => `/departments/${encodeURIComponent(subject)}${tail}`)
+        .concat(`/explorer/${encodeURIComponent(subject)}`),
+    ),
+  ];
+  const assets = new Map<string, string[]>();
+  for (const path of new Set(paths)) {
+    const asset = documentAsset(path).slice("/__documents/".length);
+    const group = assets.get(asset) || [];
+    group.push(path);
+    assets.set(asset, group);
+  }
+  const courseAliases: Record<string, string> = {};
+  for (const row of aliases) {
+    const target = courseUrl(row.code);
+    courseAliases[row.alias] =
+      courseAliases[row.alias] && courseAliases[row.alias] !== target
+        ? "/search?q=" + encodeURIComponent(row.alias)
+        : target;
+  }
+  return {
+    assets,
+    courses,
+    redirects: {
+      courses: courseAliases,
+      instructors: Object.fromEntries(instructors),
+      subjects: entries.subjects,
+    },
+  };
+}
+function getInventory() {
+  if (!building) error(404, "Build endpoint");
+  return (inventory ??= createInventory());
+}
+export async function documentEntries() {
+  const { assets, courses } = await getInventory();
+  return [
+    ...assets.keys(),
+    "redirects.json",
+    ...courses.map((c) => `contexts/${c.uid}.json`),
+  ].map((path) => ({ path }));
+}
+export async function generateDocument(path: string) {
+  const url = new URL(path, "https://uwcourses.com");
+  const data = await loadSourceDocument({
+    url,
+    params: {},
+    setHeaders: () => {},
+  });
+  const dataset = await status();
+  const document = {
+    schema_version: 1,
+    url: url.href,
+    title: pageSeo({ ...data, status: dataset }, path).title,
+    dataset,
+    data,
+  };
+  // Validate without stripping SSR-only fields; the public API serves these same bytes.
+  const serialized = JSON.parse(JSON.stringify(document));
+  documentSchemas[documentKind(path)].parse(serialized);
+  return serialized;
+}
+export async function buildDocumentAsset(asset: string) {
+  const { assets, redirects } = await getInventory();
+  if (asset === "redirects.json") return redirects;
+  if (asset.startsWith("contexts/") && asset.endsWith(".json")) {
+    const uid = asset.slice("contexts/".length, -5);
+    const [row] = await query(
+      undefined,
+      "SELECT payload FROM courses WHERE uid=?",
+      [uid],
+    );
+    if (!row) error(404, "Course not found");
+    return { context: await courseContext(JSON.parse(row.payload)) };
+  }
+  const paths = assets.get(asset);
+  if (!paths) error(404, "Document not found");
+  if (!asset.startsWith("instructors/")) return generateDocument(paths[0]);
+  const documents: Record<string, unknown> = {};
+  for (const path of paths) documents[path] = await generateDocument(path);
+  return documents;
+}

--- a/src/lib/server/documents/build.ts
+++ b/src/lib/server/documents/build.ts
@@ -39,7 +39,9 @@ async function createInventory() {
   ];
   const assets = new Map<string, string[]>();
   for (const path of new Set(paths)) {
-    const asset = documentAsset(path).slice("/__documents/".length);
+    const asset = decodeURIComponent(
+      documentAsset(path).slice("/__documents/".length),
+    );
     const group = assets.get(asset) || [];
     group.push(path);
     assets.set(asset, group);

--- a/src/lib/server/documents/index.ts
+++ b/src/lib/server/documents/index.ts
@@ -1,3 +1,5 @@
+import { building, dev } from "$app/environment";
+import { readDocument, isFilteredDocument } from "./storage";
 import { error } from "@sveltejs/kit";
 import { home } from "./home";
 import { course } from "./course";
@@ -13,7 +15,7 @@ import { maps } from "./maps";
 import type { DocumentContext } from "./types";
 
 /** Same loaders as +page.server.ts; no HTML scraping or Svelte transport decoding. */
-export async function loadDocument(context: DocumentContext) {
+export async function loadSourceDocument(context: DocumentContext) {
   const parts = context.url.pathname
     .split("/")
     .filter(Boolean)
@@ -44,4 +46,10 @@ export async function loadDocument(context: DocumentContext) {
       ? maps(context)
       : map({ ...context, params: { subject: id } });
   error(404, "Document not found");
+}
+
+export async function loadDocument(context: DocumentContext) {
+  if (building || dev || isFilteredDocument(context.url))
+    return loadSourceDocument(context);
+  return (await readDocument(context.url, context.platform)).data;
 }

--- a/src/lib/server/documents/page.ts
+++ b/src/lib/server/documents/page.ts
@@ -1,0 +1,14 @@
+import { building, dev } from "$app/environment";
+import { readDocument, isFilteredDocument } from "./storage";
+import type { DocumentContext } from "./types";
+
+/** Pages and public representations consume the same build-validated document. */
+export function pageDocument<T>(
+  source: (context: DocumentContext) => Promise<T>,
+) {
+  return async (context: DocumentContext): Promise<T> => {
+    if (building || dev || isFilteredDocument(context.url))
+      return source(context);
+    return (await readDocument(context.url, context.platform)).data as T;
+  };
+}

--- a/src/lib/server/documents/response.ts
+++ b/src/lib/server/documents/response.ts
@@ -1,3 +1,5 @@
+import { building, dev } from "$app/environment";
+import { readDocument, isFilteredDocument } from "./storage";
 import { documentSchemas, documentKind } from "$lib/api/schemas";
 import { isRedirect } from "@sveltejs/kit";
 import { loadDocument } from "./index";
@@ -29,31 +31,11 @@ export async function documentResponse(
   const url = new URL(event.url);
   url.pathname = requested.path;
   try {
-    const [data, dataset] = await Promise.all([
-      loadDocument({
-        url,
-        platform: event.platform,
-        params: {},
-        setHeaders: () => {},
-      }),
-      status(event.platform),
-    ]);
-    const seo = pageSeo({ ...data, status: dataset }, url.pathname);
-    const canonical = new URL(
-      url.pathname + url.search,
-      "https://uwcourses.com",
-    ).href;
-    const document = documentSchemas[documentKind(url.pathname)].parse(
-      JSON.parse(
-        JSON.stringify({
-          schema_version: 1,
-          url: canonical,
-          title: seo.title,
-          dataset,
-          data,
-        }),
-      ),
-    );
+    const document =
+      !building && !dev && !isFilteredDocument(url)
+        ? await readDocument(url, event.platform)
+        : await liveDocument(event, url);
+    const canonical = document.url;
     const body =
       requested.format === "json"
         ? JSON.stringify(document)
@@ -87,4 +69,27 @@ export async function documentResponse(
     }
     throw cause;
   }
+}
+
+async function liveDocument(event: RequestEvent, url: URL) {
+  const [data, dataset] = await Promise.all([
+    loadDocument({
+      url,
+      platform: event.platform,
+      params: {},
+      setHeaders: () => {},
+    }),
+    status(event.platform),
+  ]);
+  const document = JSON.parse(
+    JSON.stringify({
+      schema_version: 1,
+      url: new URL(url.pathname + url.search, "https://uwcourses.com").href,
+      title: pageSeo({ ...data, status: dataset }, url.pathname).title,
+      dataset,
+      data,
+    }),
+  );
+  documentSchemas[documentKind(url.pathname)].parse(document);
+  return document;
 }

--- a/src/lib/server/documents/storage.ts
+++ b/src/lib/server/documents/storage.ts
@@ -1,0 +1,77 @@
+import { error, redirect } from "@sveltejs/kit";
+import type { PublicDocument } from "$lib/api/schemas";
+import { normalize } from "$lib/format";
+
+// Keep historical instructor profiles without one asset per historical identity.
+export const instructorBuckets = 4096;
+export function instructorBucket(path: string) {
+  let hash = 2166136261;
+  for (const letter of path)
+    hash = Math.imul(hash ^ letter.charCodeAt(0), 16777619);
+  return ((hash >>> 0) % instructorBuckets).toString(16).padStart(3, "0");
+}
+export function documentAsset(path: string) {
+  return path.startsWith("/instructors/") &&
+    path !== "/instructors/by-rating-count"
+    ? `/__documents/instructors/${instructorBucket(path)}.json`
+    : `/__documents/pages${path === "/" ? "/index" : path}.json`;
+}
+export async function readAsset<T>(
+  path: string,
+  platform?: App.Platform,
+): Promise<T | null> {
+  if (!platform?.env.ASSETS) error(503, "Published documents unavailable");
+  const response = await platform.env.ASSETS.fetch(
+    new Request(new URL(path, "https://assets.internal")),
+  );
+  if (response.status === 404) return null;
+  if (!response.ok) error(503, "Published document could not be read");
+  return response.json() as Promise<T>;
+}
+export function isFilteredDocument(url: URL) {
+  return (
+    (url.pathname === "/search" ||
+      url.pathname === "/instructors/by-rating-count") &&
+    url.searchParams.size > 0
+  );
+}
+export async function readDocument(
+  url: URL,
+  platform?: App.Platform,
+): Promise<PublicDocument> {
+  const path = url.pathname;
+  const stored = await readAsset<
+    PublicDocument | Record<string, PublicDocument>
+  >(documentAsset(path), platform);
+  const grouped =
+    path.startsWith("/instructors/") && path !== "/instructors/by-rating-count";
+  const document = grouped
+    ? (stored as Record<string, PublicDocument> | null)?.[path]
+    : (stored as PublicDocument | null);
+  if (document) return document;
+  // Aliases only need the small routing index on a miss; normal pages read one asset.
+  const routes = await readAsset<{
+    courses: Record<string, string>;
+    instructors: Record<string, string>;
+    subjects: string[];
+  }>("/__documents/redirects.json", platform);
+  const parts = path.split("/").filter(Boolean).map(decodeURIComponent);
+  if (parts[0] === "courses" && !parts[1]?.startsWith("course_")) {
+    const target = routes?.courses[normalize(parts[1] || "")];
+    if (target && target !== path)
+      redirect(308, target + (target.includes("?") ? "" : url.search));
+  }
+  if (parts[0] === "instructors") {
+    const target = routes?.instructors[parts[1]];
+    if (target && target !== path) redirect(308, target + url.search);
+  }
+  if (
+    (parts[0] === "departments" || parts[0] === "explorer") &&
+    routes?.subjects.includes(parts[1]?.toUpperCase())
+  ) {
+    parts[1] = parts[1].toUpperCase();
+    const target = "/" + parts.map(encodeURIComponent).join("/");
+    if (target !== path) redirect(308, target + url.search);
+  }
+  error(404, "Document not found");
+}

--- a/src/lib/server/documents/storage.ts
+++ b/src/lib/server/documents/storage.ts
@@ -39,7 +39,15 @@ export async function readDocument(
   url: URL,
   platform?: App.Platform,
 ): Promise<PublicDocument> {
-  const path = url.pathname;
+  let path: string;
+  try {
+    path = url.pathname
+      .split("/")
+      .map((part) => encodeURIComponent(decodeURIComponent(part)))
+      .join("/");
+  } catch {
+    error(400, "Invalid document URL");
+  }
   const stored = await readAsset<
     PublicDocument | Record<string, PublicDocument>
   >(documentAsset(path), platform);

--- a/src/lib/server/documents/storage.ts
+++ b/src/lib/server/documents/storage.ts
@@ -58,12 +58,16 @@ export async function readDocument(
   const parts = path.split("/").filter(Boolean).map(decodeURIComponent);
   if (parts[0] === "courses" && !parts[1]?.startsWith("course_")) {
     const target = routes?.courses[normalize(parts[1] || "")];
-    if (target && target !== path)
-      redirect(308, target + (target.includes("?") ? "" : url.search));
+    if (typeof target === "string" && target !== path)
+      redirect(
+        target.startsWith("/search?") ? 307 : 308,
+        target + (target.includes("?") ? "" : url.search),
+      );
   }
   if (parts[0] === "instructors") {
     const target = routes?.instructors[parts[1]];
-    if (target && target !== path) redirect(308, target + url.search);
+    if (typeof target === "string" && target !== path)
+      redirect(308, target + url.search);
   }
   if (
     (parts[0] === "departments" || parts[0] === "explorer") &&

--- a/src/lib/server/response-cache.ts
+++ b/src/lib/server/response-cache.ts
@@ -15,7 +15,7 @@ export async function cachedResponse(
   const env = event.platform?.env;
   const release =
     env?.SITE_COMMIT && env.DATA_PROJECTION
-      ? `${env.SITE_COMMIT}:${env.DATA_PROJECTION}:${env.DATA_SLOT}`
+      ? `${env.SITE_COMMIT}:${env.DATA_PROJECTION}`
       : null;
   // Navigation transport depends on invalidation headers. Never share it with documents.
   if (

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -30,7 +30,6 @@ export interface CourseCard {
 }
 export interface Status {
   deployed_at?: string | null;
-  slot?: string | null;
   revision: string;
   repository: string;
   observed_at: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,7 +12,12 @@ export interface CourseCard {
     term: string;
     offered: boolean;
     history: ReturnType<typeof import("./discovery").gradeSummary>;
-    instructors: { instructor_url?: string; uid: string; name: string | null; quality: number | null }[];
+    instructors: {
+      instructor_url?: string;
+      uid: string;
+      name: string | null;
+      quality: number | null;
+    }[];
     claim: Claim | null;
     reviewFiles: string[];
     instructorHistory?: ReturnType<
@@ -24,6 +29,8 @@ export interface CourseCard {
   };
 }
 export interface Status {
+  deployed_at?: string | null;
+  slot?: string | null;
   revision: string;
   repository: string;
   observed_at: string;

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,1 +1,3 @@
-export { home as load } from "$lib/server/documents/home";
+import { home } from "$lib/server/documents/home";
+import { pageDocument } from "$lib/server/documents/page";
+export const load = pageDocument(home);

--- a/src/routes/__documents/[...path]/+server.ts
+++ b/src/routes/__documents/[...path]/+server.ts
@@ -1,0 +1,15 @@
+import { json } from "@sveltejs/kit";
+import {
+  documentEntries,
+  buildDocumentAsset,
+} from "$lib/server/documents/build";
+export const prerender = true;
+export const entries = documentEntries;
+export async function GET({ params }) {
+  return json(await buildDocumentAsset(params.path), {
+    headers: {
+      "X-Robots-Tag": "noindex",
+      "Cache-Control": "public, max-age=0, must-revalidate",
+    },
+  });
+}

--- a/src/routes/courses/[collection=collection]/+page.server.ts
+++ b/src/routes/courses/[collection=collection]/+page.server.ts
@@ -1,1 +1,3 @@
-export { course_collection as load } from "$lib/server/documents/course-collection";
+import { course_collection } from "$lib/server/documents/course-collection";
+import { pageDocument } from "$lib/server/documents/page";
+export const load = pageDocument(course_collection);

--- a/src/routes/courses/[courseIdentifier]/+page.server.ts
+++ b/src/routes/courses/[courseIdentifier]/+page.server.ts
@@ -1,1 +1,3 @@
-export { course as load } from "$lib/server/documents/course";
+import { course } from "$lib/server/documents/course";
+import { pageDocument } from "$lib/server/documents/page";
+export const load = pageDocument(course);

--- a/src/routes/departments/[subject]/+page.server.ts
+++ b/src/routes/departments/[subject]/+page.server.ts
@@ -1,1 +1,3 @@
-export { department as load } from "$lib/server/documents/department";
+import { department } from "$lib/server/documents/department";
+import { pageDocument } from "$lib/server/documents/page";
+export const load = pageDocument(department);

--- a/src/routes/departments/[subject]/[collection=collection]/+page.server.ts
+++ b/src/routes/departments/[subject]/[collection=collection]/+page.server.ts
@@ -1,1 +1,3 @@
-export { department_collection as load } from "$lib/server/documents/department-collection";
+import { department_collection } from "$lib/server/documents/department-collection";
+import { pageDocument } from "$lib/server/documents/page";
+export const load = pageDocument(department_collection);

--- a/src/routes/departments/[subject]/catalog/+page.server.ts
+++ b/src/routes/departments/[subject]/catalog/+page.server.ts
@@ -1,1 +1,3 @@
-export { catalog as load } from "$lib/server/documents/catalog";
+import { catalog } from "$lib/server/documents/catalog";
+import { pageDocument } from "$lib/server/documents/page";
+export const load = pageDocument(catalog);

--- a/src/routes/explorer/[subject]/+page.server.ts
+++ b/src/routes/explorer/[subject]/+page.server.ts
@@ -1,1 +1,3 @@
-export { map as load } from "$lib/server/documents/map";
+import { map } from "$lib/server/documents/map";
+import { pageDocument } from "$lib/server/documents/page";
+export const load = pageDocument(map);

--- a/src/routes/explorer/all/+page.server.ts
+++ b/src/routes/explorer/all/+page.server.ts
@@ -1,1 +1,3 @@
-export { maps as load } from "$lib/server/documents/maps";
+import { maps } from "$lib/server/documents/maps";
+import { pageDocument } from "$lib/server/documents/page";
+export const load = pageDocument(maps);

--- a/src/routes/instructors/[uid]/+page.server.ts
+++ b/src/routes/instructors/[uid]/+page.server.ts
@@ -1,1 +1,3 @@
-export { instructor as load } from "$lib/server/documents/instructor";
+import { instructor } from "$lib/server/documents/instructor";
+import { pageDocument } from "$lib/server/documents/page";
+export const load = pageDocument(instructor);

--- a/src/routes/instructors/by-rating-count/+page.server.ts
+++ b/src/routes/instructors/by-rating-count/+page.server.ts
@@ -1,1 +1,3 @@
-export { instructors as load } from "$lib/server/documents/instructors";
+import { instructors } from "$lib/server/documents/instructors";
+import { pageDocument } from "$lib/server/documents/page";
+export const load = pageDocument(instructors);

--- a/src/routes/search/+page.server.ts
+++ b/src/routes/search/+page.server.ts
@@ -1,1 +1,3 @@
-export { search as load } from "$lib/server/documents/search";
+import { search } from "$lib/server/documents/search";
+import { pageDocument } from "$lib/server/documents/page";
+export const load = pageDocument(search);

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -17,10 +17,10 @@ export default {
       },
     },
     prerender: {
-      concurrency: 16,
+      concurrency: 4,
       handleHttpError: "fail",
       handleMissingId: "warn",
-      entries: ["/sitemap.xml", "/social/manifest.json", "/openapi.json"],
+      entries: ["*", "/sitemap.xml", "/social/manifest.json", "/openapi.json"],
     },
   },
 };

--- a/web/README.md
+++ b/web/README.md
@@ -1,6 +1,6 @@
 # Website
 
-SvelteKit SSR on Cloudflare Workers, with cached responses, static assets, and Drizzle + D1. HF is the source of truth.
+SvelteKit SSR reads build-generated JSON through Cloudflare Static Assets. HF is the source of truth; Drizzle + D1 serves search, filters, and paginated records.
 
 ```sh
 bun install --frozen-lockfile
@@ -20,7 +20,7 @@ uv run --locked uwcourses-site assets-check
 bun x playwright test
 ```
 
-Production preview runs the built Cloudflare Worker with Wrangler and uses local D1, not `.site/site.sqlite`. After importing a new dataset, stop the preview and refresh its database before restarting:
+Production preview reads page documents from built assets. Interactive search and pagination use local D1, not `.site/site.sqlite`. After importing a new dataset, stop the preview and refresh its database before restarting:
 
 ```sh
 set -e
@@ -56,10 +56,12 @@ Sitemaps remain build-time assets. Their `lastmod` is the dataset observation ti
 
 Append `.json` or `.md` to a page URL (`/courses/COMPSCI_300.json`, `/search.md?q=java`); the homepage uses `/index.json` and `/index.md`. HTML advertises both via HTTP `Link` and `<link rel="alternate">`. These are public, read-only APIs with CORS enabled; alternate formats are noindex.
 
-`/openapi.json` serves OpenAPI 3.1, generated from the same Zod schemas used to validate document responses. TypeScript consumers can import inferred types from `src/lib/api/schemas.ts` or generate a client from the spec. Core entities have named fields; additional source fields use the recursive `JsonValue` schema. The existing `/api` interaction endpoints are also documented and validated.
+`/openapi.json` serves OpenAPI 3.1, generated from the same Zod schemas used to validate document responses. TypeScript consumers can import inferred types from `src/lib/api/schemas.ts` or generate a client from the spec. Documents are validated during the build; query-dependent responses are validated at runtime. Core entities have named fields; additional source fields use the recursive `JsonValue` schema. The existing `/api` interaction endpoints are also documented and validated.
 
 JSON has `schema_version`, `url`, `title`, `dataset`, and `data`. The dataset includes its pinned HF revision and projection identity. `data` is the same payload the page loader returns; nested LLM evidence and model provenance are retained. Large history/trace files remain linked from that payload rather than duplicated. Markdown renders the same records, with tables and JSON blocks for nested data. Neither format requires browser JavaScript.
 
 Public GET documents are cached for 24 hours in Cloudflare's Cache API. Keys include the deployment, data projection, database slot, URL, and query. Browser responses revalidate with ETags. Cache hits still invoke the Worker; the cache is local to each data center. Authenticated/cookie requests, navigation transport, errors, and existing `/api` endpoints bypass this document cache. Preview caching requires `SITE_COMMIT` and `DATA_PROJECTION`; without them requests render directly.
 
-Drizzle owns website reads; the Python importer owns the read-model schema and ordered SQL import. Complex FTS and grade aggregations use bound SQL through Drizzle on D1. Development reads the imported local SQLite database.
+Canonical page loaders and public representations share generated documents. Course comparisons are computed during prerender and also emitted as compact assets for search badges. Historical instructor profiles are grouped into 4,096 deterministic buckets to bound the file count. The native SvelteKit prerender endpoint generates these assets; no separate generation script is required. HTML remains SSR and term controls remain interactive.
+
+Drizzle owns interactive database reads; the Python importer owns the read-model schema and ordered SQL import. Complex FTS and grade aggregations use bound SQL through Drizzle on D1. Development reads the imported local SQLite database.

--- a/web/README.md
+++ b/web/README.md
@@ -25,8 +25,9 @@ Production preview reads page documents from built assets. Interactive search an
 ```sh
 set -e
 for part in .site/sql/*.sql; do
-  bun x wrangler d1 execute DB_A --local --file="$part"
+  bun x wrangler d1 execute DB --local --file="$part"
 done
+bun x wrangler d1 execute DB --local --command "INSERT OR REPLACE INTO metadata VALUES('serving','00000000000000000000000000000000');"
 bun run preview --ip 0.0.0.0 --port 4173
 ```
 
@@ -34,13 +35,13 @@ bun run preview --ip 0.0.0.0 --port 4173
 
 ## Cloudflare setup
 
-The A/B D1 database IDs are configured in `wrangler.json` as `DB_A` and `DB_B`. Set `CLOUDFLARE_ACCOUNT_ID` as a GitHub variable and `CLOUDFLARE_API_TOKEN` as a secret in the `production` environment. The token needs Workers Scripts and D1 edit permissions. `HF_TOKEN` is optional for the public dataset.
+The single D1 database is configured in `wrangler.json` as `DB`. Set `CLOUDFLARE_ACCOUNT_ID` as a GitHub variable and `CLOUDFLARE_API_TOKEN` as a secret in the `production` environment. The token needs Workers Scripts and D1 edit permissions. `HF_TOKEN` is optional for the public dataset.
 
 Run the **Svelte** workflow manually with **First deployment** enabled once to create the Worker. Validate its workers.dev preview, then attach `uwcourses.com` in Cloudflare. Subsequent runs leave that option disabled.
 
-The Svelte workflow checks pushes and pull requests; its production job runs at 03:17 America/Los_Angeles and also supports **Run workflow**. It pins HF, imports locally, builds and tests, then uses native Wrangler commands to import the inactive D1 database and deploy matching code/assets with the new database selection. Only this workflow should modify these production databases. When the HF revision and importer are unchanged, the active database is reused while the site still rebuilds and redeploys. The workflow calls `uwcourses-site deploy`; database selection, ordered imports, verification and deployment live in that tested CLI command, not inline Bash. No separate deployment scripts or Cloudflare cron are needed.
+The Svelte workflow checks pushes and pull requests; its production job runs at 03:17 America/Los_Angeles and also supports **Run workflow**. It imports HF, generates and validates static JSON, builds and tests, then calls `uwcourses-site deploy`. The tested CLI imports D1 only when the database does not already match the release, verifies it, and deploys matching code/assets. No separate deployment scripts or Cloudflare cron are needed.
 
-Failures before deployment preserve the active database/site. The previous deployment can be restored using Cloudflare's Worker rollback while its database remains intact; the next import into that slot replaces it. Production jobs are serialized. GitHub stores release metadata for each run. GitHub may disable schedules after 60 days without repository activity; re-enable the workflow from Actions if needed.
+Imports temporarily disable search/filter queries. Static pages and their JSON/Markdown remain available. A verified-import marker and projection check prevent partial or mismatched query results; requests check before and after querying. Failed imports can be retried, and failed Worker publication reuses a matching completed import. Worker rollback does not restore D1; restore the matching dataset to recover queries after a data rollback. Production jobs are serialized and only this workflow should modify the production database. GitHub stores release metadata for each run.
 
 D1 SQL is emitted as ordered 16 MiB files, with each statement below 100 KB. The workflow imports them sequentially and checks a completion marker and dataset identity before deployment.
 
@@ -60,7 +61,7 @@ Append `.json` or `.md` to a page URL (`/courses/COMPSCI_300.json`, `/search.md?
 
 JSON has `schema_version`, `url`, `title`, `dataset`, and `data`. The dataset includes its pinned HF revision and projection identity. `data` is the same payload the page loader returns; nested LLM evidence and model provenance are retained. Large history/trace files remain linked from that payload rather than duplicated. Markdown renders the same records, with tables and JSON blocks for nested data. Neither format requires browser JavaScript.
 
-Public GET documents are cached for 24 hours in Cloudflare's Cache API. Keys include the deployment, data projection, database slot, URL, and query. Browser responses revalidate with ETags. Cache hits still invoke the Worker; the cache is local to each data center. Authenticated/cookie requests, navigation transport, errors, and existing `/api` endpoints bypass this document cache. Preview caching requires `SITE_COMMIT` and `DATA_PROJECTION`; without them requests render directly.
+Public GET documents are cached for 24 hours in Cloudflare's Cache API. Keys include the deployment, data projection, URL, and query. Browser responses revalidate with ETags. Cache hits still invoke the Worker; the cache is local to each data center. Authenticated/cookie requests, navigation transport, errors, and existing `/api` endpoints bypass this document cache. Preview caching requires `SITE_COMMIT` and `DATA_PROJECTION`; without them requests render directly.
 
 Canonical page loaders and public representations share generated documents. Course comparisons are computed during prerender and also emitted as compact assets for search badges. Historical instructor profiles are grouped into 4,096 deterministic buckets to bound the file count. The native SvelteKit prerender endpoint generates these assets; no separate generation script is required. HTML remains SSR and term controls remain interactive.
 

--- a/web/tests/browser/documents.spec.ts
+++ b/web/tests/browser/documents.spec.ts
@@ -13,6 +13,7 @@ test("JSON document families satisfy the published contracts", async ({
     "/instructors/by-rating-count",
     "/departments",
     "/departments/COMPSCI",
+    "/departments/ANAT%26PHY",
     "/departments/COMPSCI/catalog",
     "/departments/COMPSCI/easiest",
     "/courses/hardest",

--- a/web/tests/database-availability.test.ts
+++ b/web/tests/database-availability.test.ts
@@ -1,0 +1,62 @@
+import { expect, it, vi } from "vitest";
+import publishedStatus from "../../.site/status.json";
+const { read } = vi.hoisted(() => ({ read: vi.fn() }));
+vi.mock("../../src/lib/server/database", () => ({
+  database: () => ({ select: () => ({ from: () => ({ where: read }) }) }),
+}));
+import { withDatabaseAvailability } from "../../src/lib/server/database-availability";
+const ready = [
+  { key: "serving", value: "a".repeat(32) },
+  { key: "ready", value: "true" },
+  { key: "status", value: JSON.stringify(publishedStatus) },
+];
+it("serves queries only while the database matches the static documents", async () => {
+  read.mockReset().mockResolvedValue(ready);
+  const render = vi.fn(async () => "results");
+  expect(await withDatabaseAvailability(undefined, render)).toBe("results");
+  expect(read).toHaveBeenCalledTimes(2);
+  for (const state of [
+    [],
+    [{ key: "ready", value: "false" }],
+    [
+      ...ready.filter((row) => row.key !== "status"),
+      { key: "status", value: '{"projection_id":"old"}' },
+    ],
+  ]) {
+    read.mockReset().mockResolvedValue(state);
+    render.mockClear();
+    await expect(
+      withDatabaseAvailability(undefined, render),
+    ).rejects.toMatchObject({ status: 503 });
+    expect(render).not.toHaveBeenCalled();
+  }
+});
+it("discards results when an import starts during a request", async () => {
+  read.mockReset().mockResolvedValue([]).mockResolvedValueOnce(ready);
+  await expect(
+    withDatabaseAvailability(undefined, async () => "partial results"),
+  ).rejects.toMatchObject({ status: 503 });
+});
+it("turns a dropped schema into maintenance but preserves unrelated query failures", async () => {
+  read.mockReset().mockRejectedValue(new Error("no such table: metadata"));
+  await expect(
+    withDatabaseAvailability(undefined, async () => "results"),
+  ).rejects.toMatchObject({ status: 503 });
+  read.mockReset().mockResolvedValue(ready);
+  const failure = new Error("query bug");
+  await expect(
+    withDatabaseAvailability(undefined, async () => {
+      throw failure;
+    }),
+  ).rejects.toBe(failure);
+});
+
+it("rejects mixed results even if an import completes with the same projection", async () => {
+  const next = ready.map((row) =>
+    row.key === "serving" ? { ...row, value: "b".repeat(32) } : row,
+  );
+  read.mockReset().mockResolvedValue(next).mockResolvedValueOnce(ready);
+  await expect(
+    withDatabaseAvailability(undefined, async () => "mixed results"),
+  ).rejects.toMatchObject({ status: 503 });
+});

--- a/web/tests/database-availability.test.ts
+++ b/web/tests/database-availability.test.ts
@@ -17,6 +17,7 @@ it("serves queries only while the database matches the static documents", async 
   expect(read).toHaveBeenCalledTimes(2);
   for (const state of [
     [],
+    ready.filter((row) => row.key !== "serving"),
     [{ key: "ready", value: "false" }],
     [
       ...ready.filter((row) => row.key !== "status"),

--- a/web/tests/documents.test.ts
+++ b/web/tests/documents.test.ts
@@ -89,7 +89,7 @@ it("caches successful documents, revalidates, and bypasses navigation and creden
       url: new URL("https://uwcourses.com/search.json?q=java"),
       request: new Request("https://uwcourses.com/search.json?q=java"),
       platform: {
-        env: { SITE_COMMIT: "a", DATA_PROJECTION: "b", DATA_SLOT: "a" },
+        env: { SITE_COMMIT: "a", DATA_PROJECTION: "b" },
         context: { waitUntil: (p: Promise<unknown>) => writes.push(p) },
       },
       isDataRequest: false,

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -118,7 +118,7 @@ it("omits empty rankings while preserving populated ranking pages", async () => 
       pageSeo({ subject, collection: "easiest", results }, path).noindex,
     ).toBe(results.total === 0);
   }
-});
+}, 30_000);
 
 it("does not invent missing catalog descriptions or promote unnamed instructor records", () => {
   const seo = pageSeo(

--- a/web/tests/static-documents.test.ts
+++ b/web/tests/static-documents.test.ts
@@ -8,6 +8,8 @@ import {
 } from "../../src/lib/server/documents/storage";
 import { pageDocument } from "../../src/lib/server/documents/page";
 
+import { courseContexts } from "../../src/lib/server/course-context";
+
 const document = {
   schema_version: 1,
   url: "https://uwcourses.com/courses/COMPSCI_300",
@@ -103,6 +105,24 @@ describe("static page documents", () => {
     await expect(
       readDocument(context("/courses/missing", env).url, env),
     ).rejects.toMatchObject({ status: 404 });
+  });
+  it("uses precomputed comparisons for search cards without reading grade histories", async () => {
+    const precomputed = { all: { gpa: 3.2 }, terms: {}, benchmarks: {} };
+    const { platform: env } = platform({
+      "/__documents/contexts/course-one.json": { context: precomputed },
+    });
+    const course = {
+      course_uid: "course-one",
+      get grades() {
+        throw new Error("Grade history scanned at runtime");
+      },
+    };
+    expect((await courseContexts([course], env)).get("course-one")).toEqual(
+      precomputed,
+    );
+    await expect(
+      courseContexts([{ course_uid: "missing" }], env),
+    ).rejects.toMatchObject({ status: 503 });
   });
   it("does not turn asset outages into a database scan or a 404", async () => {
     const env = {

--- a/web/tests/static-documents.test.ts
+++ b/web/tests/static-documents.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest";
+vi.mock("$app/environment", () => ({ building: false, dev: false }));
+import {
+  documentAsset,
+  instructorBucket,
+  readDocument,
+  isFilteredDocument,
+} from "../../src/lib/server/documents/storage";
+import { pageDocument } from "../../src/lib/server/documents/page";
+
+const document = {
+  schema_version: 1,
+  url: "https://uwcourses.com/courses/COMPSCI_300",
+  title: "Programming II",
+  dataset: { revision: "test" },
+  data: {
+    course: { course_id: "COMPSCI 300" },
+    context: { precomputed: true },
+  },
+};
+function platform(files: Record<string, unknown>) {
+  const fetch = vi.fn(async (request: Request) => {
+    const path = new URL(request.url).pathname;
+    return path in files
+      ? Response.json(files[path])
+      : new Response(null, { status: 404 });
+  });
+  const env = new Proxy(
+    { ASSETS: { fetch } },
+    {
+      get(target, key) {
+        if (key === "DB_A" || key === "DB_B")
+          throw new Error("Page attempted a database read");
+        return Reflect.get(target, key);
+      },
+    },
+  );
+  return { platform: { env } as unknown as App.Platform, fetch };
+}
+const context = (path: string, env: App.Platform) => ({
+  url: new URL(path, "https://uwcourses.com"),
+  params: {},
+  platform: env,
+  setHeaders: () => {},
+});
+
+describe("static page documents", () => {
+  it("serves SSR and public data from the same generated document without querying D1", async () => {
+    const { platform: env, fetch } = platform({
+      [documentAsset("/courses/COMPSCI_300")]: document,
+    });
+    const source = vi.fn(async () => ({ dynamic: true }));
+    const ctx = context("/courses/COMPSCI_300?term=1272", env);
+    const page = await pageDocument(source)(ctx);
+    const api = await readDocument(ctx.url, env);
+    expect(page).toEqual(api.data);
+    expect(source).not.toHaveBeenCalled();
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+  it("keeps query-dependent search live, including validation of invalid filters", async () => {
+    const { platform: env, fetch } = platform({});
+    const source = vi.fn(async () => ({ query: true }));
+    expect(await pageDocument(source)(context("/search?q=java", env))).toEqual({
+      query: true,
+    });
+    expect(source).toHaveBeenCalledOnce();
+    expect(fetch).not.toHaveBeenCalled();
+    expect(isFilteredDocument(new URL("https://uwcourses.com/search"))).toBe(
+      false,
+    );
+  });
+  it("selects only the requested instructor from a bucket", async () => {
+    const path = "/instructors/HOBBES_LEGAULT";
+    const profile = {
+      ...document,
+      url: "https://uwcourses.com" + path,
+      data: { instructor: { name: "Hobbes Legault" } },
+    };
+    const { platform: env } = platform({
+      [documentAsset(path)]: {
+        [path]: profile,
+        "/instructors/OTHER": document,
+      },
+    });
+    expect(await readDocument(context(path, env).url, env)).toEqual(profile);
+    expect(instructorBucket(path)).toMatch(/^[0-9a-f]{3}$/);
+    expect(documentAsset("/instructors/by-rating-count")).toContain("/pages/");
+  });
+  it("preserves aliases and unknown-page errors without a database fallback", async () => {
+    const { platform: env } = platform({
+      "/__documents/redirects.json": {
+        courses: { COMPSCI300: "/courses/COMPSCI_300" },
+        instructors: {},
+        subjects: ["COMPSCI"],
+      },
+    });
+    await expect(
+      readDocument(context("/courses/cs300?term=1272", env).url, env),
+    ).rejects.toMatchObject({
+      status: 308,
+      location: "/courses/COMPSCI_300?term=1272",
+    });
+    await expect(
+      readDocument(context("/courses/missing", env).url, env),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+  it("does not turn asset outages into a database scan or a 404", async () => {
+    const env = {
+      env: {
+        ASSETS: { fetch: async () => new Response(null, { status: 500 }) },
+      },
+    } as unknown as App.Platform;
+    await expect(
+      readDocument(context("/courses/COMPSCI_300", env).url, env),
+    ).rejects.toMatchObject({ status: 503 });
+  });
+});

--- a/web/tests/static-documents.test.ts
+++ b/web/tests/static-documents.test.ts
@@ -31,7 +31,7 @@ function platform(files: Record<string, unknown>) {
     { ASSETS: { fetch } },
     {
       get(target, key) {
-        if (key === "DB_A" || key === "DB_B")
+        if (key === "DB")
           throw new Error("Page attempted a database read");
         return Reflect.get(target, key);
       },
@@ -87,6 +87,19 @@ describe("static page documents", () => {
     expect(await readDocument(context(path, env).url, env)).toEqual(profile);
     expect(instructorBucket(path)).toMatch(/^[0-9a-f]{3}$/);
     expect(documentAsset("/instructors/by-rating-count")).toContain("/pages/");
+  });
+  it("normalizes equivalent URL encodings before selecting a document", async () => {
+    const path = "/departments/ANAT%26PHY";
+    const { platform: env } = platform({ [documentAsset(path)]: document });
+    for (const input of [
+      path,
+      "/departments/ANAT&PHY",
+      "/departments/ANAT%26PHY",
+    ]) {
+      expect(await readDocument(context(input, env).url, env)).toEqual(
+        document,
+      );
+    }
   });
   it("preserves aliases and unknown-page errors without a database fallback", async () => {
     const { platform: env } = platform({

--- a/web/tests/test_deployment.py
+++ b/web/tests/test_deployment.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 from uwcourses_site.deployment import (
     Release,
     deploy,
-    select_slot,
+    database_matches,
     verify_database,
     worker_state,
 )
@@ -16,28 +16,6 @@ from uwcourses_site.deployment import (
 
 class DeploymentTests(unittest.TestCase):
     release = Release("a" * 40, "b" * 64, 10)
-
-    def test_first_deployment_is_explicit(self):
-        with self.assertRaises(ValueError):
-            select_slot(None, self.release, False)
-        self.assertEqual(select_slot(None, self.release, True).binding, "DB_A")
-
-    def test_only_inactive_slot_is_imported(self):
-        for active, target in (("a", "b"), ("b", "a")):
-            plan = select_slot({"DATA_SLOT": active}, self.release, False)
-            self.assertEqual(plan.slot, target)
-            self.assertTrue(plan.import_required)
-        with self.assertRaises(ValueError):
-            select_slot({"DATA_SLOT": "unknown"}, self.release, True)
-
-    def test_same_projection_reuses_active_database(self):
-        plan = select_slot(
-            {"DATA_SLOT": "b", "DATA_PROJECTION": self.release.projection},
-            self.release,
-            False,
-        )
-        self.assertEqual(plan.slot, "b")
-        self.assertFalse(plan.import_required)
 
     def report(self, **changes):
         status = {
@@ -66,7 +44,9 @@ class DeploymentTests(unittest.TestCase):
             with self.assertRaises(ValueError):
                 verify_database(self.report(**changes), self.release)
 
-    def run_deploy(self, failure=None, changed=False, reuse=False):
+    def run_deploy(
+        self, failure=None, changed=False, reuse=False, missing=False, first=False
+    ):
         with TemporaryDirectory() as directory:
             root = Path(directory)
             (root / "sql").mkdir()
@@ -88,17 +68,13 @@ class DeploymentTests(unittest.TestCase):
                     {
                         "name": "uw-coursemap",
                         "d1_databases": [
-                            {"binding": "DB_A", "database_id": "a"},
-                            {"binding": "DB_B", "database_id": "b"},
+                            {"binding": "DB", "database_id": "single"},
                         ],
                     }
                 )
             )
-            initial = {
-                "DATA_SLOT": "a",
-                "DATA_PROJECTION": self.release.projection if reuse else "old",
-            }
-            states = [initial, {"DATA_SLOT": "b"} if changed else initial]
+            initial = None if missing else {"DB": "single", "DATA_PROJECTION": "old"}
+            states = [initial, {"DB": "changed"} if changed else initial]
             calls = []
 
             def command(config, *args, **kwargs):
@@ -114,23 +90,51 @@ class DeploymentTests(unittest.TestCase):
                 ),
                 patch("uwcourses_site.deployment.worker_state", side_effect=states),
                 patch("uwcourses_site.deployment.wrangler", side_effect=command),
+                patch("uwcourses_site.deployment.database_matches", return_value=reuse),
                 patch("uwcourses_site.deployment.subprocess.run") as run,
             ):
                 run.return_value.stdout = "c" * 40
-                if failure or changed:
+                if failure or changed or (missing and not first):
                     with self.assertRaises(
                         (ValueError, RuntimeError, subprocess.CalledProcessError)
                     ):
-                        deploy(config, root)
+                        deploy(config, root, first=first)
                     self.assertFalse(any(call[0] == "deploy" for call in calls))
+                    self.assertFalse(
+                        any("VALUES('serving'" in str(call[-1]) for call in calls)
+                    )
                 else:
-                    deploy(config, root)
+                    deploy(config, root, first=first)
                     self.assertEqual(calls[-1][0], "deploy")
+                    self.assertIn("VALUES('serving'", calls[-2][-1])
                     imports = [call for call in calls if "--file" in call]
                     self.assertEqual(len(imports), 0 if reuse else 2)
                     if imports:
-                        self.assertTrue(all(call[2] == "DB_B" for call in imports))
+                        self.assertTrue(all(call[2] == "DB" for call in imports))
+                        self.assertIn("VALUES('ready','false')", calls[0][-1])
+                        self.assertLess(calls.index(calls[0]), calls.index(imports[0]))
                         self.assertTrue(imports[0][-1].endswith("0001.sql"))
+
+    def test_first_deployment_is_explicit(self):
+        self.run_deploy(missing=True)
+        self.run_deploy(missing=True, first=True)
+
+    @patch("uwcourses_site.deployment.wrangler")
+    def test_database_readiness_controls_reuse_after_failed_publication(self, command):
+        tables = json.dumps([{"results": [{"tables": 2}], "success": True}])
+        for report, expected in [
+            (self.report(), True),
+            (self.report(ready="false"), False),
+            (self.report(status="{}"), False),
+        ]:
+            command.side_effect = [tables, report]
+            self.assertEqual(
+                database_matches(Path("wrangler.json"), self.release), expected
+            )
+        command.side_effect = [
+            json.dumps([{"results": [{"tables": 0}], "success": True}])
+        ]
+        self.assertFalse(database_matches(Path("wrangler.json"), self.release))
 
     def test_import_verify_and_publish_order(self):
         self.run_deploy()

--- a/web/uwcourses_site/deployment.py
+++ b/web/uwcourses_site/deployment.py
@@ -1,6 +1,6 @@
 """Publish a verified website release with native Wrangler commands.
 
-The inactive D1 slot is imported and verified before changing the live Worker.
+A single D1 is marked unavailable during imports, then verified before publishing.
 No shell is involved; a failed import/verification never proceeds to deployment.
 """
 
@@ -11,6 +11,7 @@ import os
 from pathlib import Path
 import re
 import subprocess
+from uuid import uuid4
 from typing import Any
 
 import requests
@@ -36,31 +37,6 @@ class Release:
         return cls(data["revision"], data["projection_id"], data["courses"])
 
 
-@dataclass(frozen=True)
-class Plan:
-    slot: str
-    import_required: bool
-
-    @property
-    def binding(self) -> str:
-        return "DB_" + self.slot.upper()
-
-
-def select_slot(state: dict[str, str] | None, release: Release, first: bool) -> Plan:
-    if state is None:
-        if not first:
-            raise ValueError(
-                "Worker does not exist; enable first deployment explicitly"
-            )
-        return Plan("a", True)
-    active = state.get("DATA_SLOT")
-    if active not in ("a", "b"):
-        raise ValueError("Cannot determine the active D1 slot; refusing to import")
-    if state.get("DATA_PROJECTION") == release.projection:
-        return Plan(active, False)
-    return Plan("b" if active == "a" else "a", True)
-
-
 def worker_state(account: str, token: str, worker: str) -> dict[str, str] | None:
     response = requests.get(
         f"https://api.cloudflare.com/client/v4/accounts/{account}/workers/scripts/{worker}/settings",
@@ -73,11 +49,12 @@ def worker_state(account: str, token: str, worker: str) -> dict[str, str] | None
     data = response.json()
     if data.get("success") is not True:
         raise RuntimeError("Cloudflare could not read the current Worker settings")
-    names = {"DATA_SLOT", "DATA_PROJECTION", "SITE_COMMIT"}
+    names = {"DATA_PROJECTION", "SITE_COMMIT"}
     return {
-        binding["name"]: binding["text"]
+        binding["name"]: binding.get("text", binding.get("id"))
         for binding in data["result"]["bindings"]
-        if binding.get("name") in names and "text" in binding
+        if (binding.get("name") in names and "text" in binding)
+        or binding.get("type") == "d1"
     }
 
 
@@ -94,7 +71,7 @@ def wrangler(config: Path, *args: str, capture: bool = False) -> str:
 def verify_database(output: str, release: Release) -> Any:
     results = json.loads(output)
     if not results or results[0].get("success") is False:
-        raise ValueError("Staged D1 verification failed")
+        raise ValueError("D1 verification failed")
     row = results[0]["results"][0]
     status = json.loads(row["status"])
     if (
@@ -103,7 +80,7 @@ def verify_database(output: str, release: Release) -> Any:
         or status.get("projection_id") != release.projection
         or status.get("revision") != release.revision
     ):
-        raise ValueError("Staged database does not match the built release")
+        raise ValueError("Database does not match the built release")
     return results
 
 
@@ -113,12 +90,9 @@ def deploy(config: Path, site: Path, first: bool = False) -> None:
     worker = settings["name"]
     if not re.fullmatch(r"[a-zA-Z0-9_-]+", worker):
         raise ValueError("Invalid Worker name")
-    databases = {row["binding"]: row["database_id"] for row in settings["d1_databases"]}
-    if (
-        not {"DB_A", "DB_B"} <= databases.keys()
-        or databases["DB_A"] == databases["DB_B"]
-    ):
-        raise ValueError("Configure distinct DB_A and DB_B databases")
+    databases = settings["d1_databases"]
+    if len(databases) != 1 or databases[0]["binding"] != "DB":
+        raise ValueError("Configure one D1 database with binding DB")
     account = os.environ["CLOUDFLARE_ACCOUNT_ID"]
     token = os.environ["CLOUDFLARE_API_TOKEN"]
     if not re.fullmatch(r"[a-fA-F0-9]{32}", account) or not token:
@@ -127,24 +101,33 @@ def deploy(config: Path, site: Path, first: bool = False) -> None:
         ["git", "rev-parse", "HEAD"], check=True, capture_output=True, text=True
     ).stdout.strip()
     state = worker_state(account, token, worker)
-    plan = select_slot(state, release, first)
-    print(
-        f"Release {release.revision}: slot {plan.slot.upper()}, import={plan.import_required}",
-        flush=True,
-    )
-    if plan.import_required:
+    if state is None and not first:
+        raise ValueError("Worker does not exist; enable first deployment explicitly")
+    reuse = database_matches(config, release)
+    print(f"Release {release.revision}: import={not reuse}", flush=True)
+    if not reuse:
         parts = sorted((site / "sql").glob("*.sql"))
         if not parts:
             raise ValueError("No dataset SQL import files found")
+        # This precedes every destructive import statement. Requests fail closed
+        # while ready is false/missing or the database belongs to another release.
+        wrangler(
+            config,
+            "d1",
+            "execute",
+            "DB",
+            "--remote",
+            "--command",
+            "CREATE TABLE IF NOT EXISTS metadata(key TEXT PRIMARY KEY,value TEXT); "
+            "INSERT OR REPLACE INTO metadata VALUES('ready','false');",
+        )
         for part in parts:
-            wrangler(
-                config, "d1", "execute", plan.binding, "--remote", "--file", str(part)
-            )
+            wrangler(config, "d1", "execute", "DB", "--remote", "--file", str(part))
     output = wrangler(
         config,
         "d1",
         "execute",
-        plan.binding,
+        "DB",
         "--remote",
         "--json",
         "--command",
@@ -159,9 +142,16 @@ def deploy(config: Path, site: Path, first: bool = False) -> None:
         raise RuntimeError("Worker changed during preparation; refusing to replace it")
     wrangler(
         config,
+        "d1",
+        "execute",
+        "DB",
+        "--remote",
+        "--command",
+        f"INSERT OR IGNORE INTO metadata VALUES('serving','{uuid4().hex}');",
+    )
+    wrangler(
+        config,
         "deploy",
-        "--var",
-        f"DATA_SLOT:{plan.slot}",
         "--var",
         f"SITE_COMMIT:{commit}",
         "--var",
@@ -169,3 +159,37 @@ def deploy(config: Path, site: Path, first: bool = False) -> None:
         "--var",
         f"DEPLOYED_AT:{datetime.now(timezone.utc).isoformat()}",
     )
+
+
+def database_matches(config: Path, release: Release) -> bool:
+    # Inspect the database itself so a retry after failed Worker publication can
+    # reuse an already verified import, even if the live Worker is still older.
+    output = wrangler(
+        config,
+        "d1",
+        "execute",
+        "DB",
+        "--remote",
+        "--json",
+        "--command",
+        "SELECT count(*) tables FROM sqlite_master WHERE type='table' AND name IN ('metadata','courses')",
+    )
+    if json.loads(output)[0]["results"][0]["tables"] != 2:
+        return False
+    output = wrangler(
+        config,
+        "d1",
+        "execute",
+        "DB",
+        "--remote",
+        "--json",
+        "--command",
+        "SELECT (SELECT value FROM metadata WHERE key='ready') ready, "
+        "(SELECT value FROM metadata WHERE key='status') status, "
+        "(SELECT count(*) FROM courses) courses",
+    )
+    try:
+        verify_database(output, release)
+        return True
+    except (ValueError, TypeError, KeyError, IndexError):
+        return False

--- a/wrangler.json
+++ b/wrangler.json
@@ -15,17 +15,9 @@
   },
   "d1_databases": [
     {
-      "binding": "DB_A",
-      "database_name": "uw-coursemap-a",
-      "database_id": "b7218037-080d-4484-b3a7-e8027aa31050"
-    },
-    {
-      "binding": "DB_B",
-      "database_name": "uw-coursemap-b",
-      "database_id": "3efdeb2d-15f6-4240-aa79-0f6dca156f28"
+      "binding": "DB",
+      "database_name": "uw-coursemap",
+      "database_id": "acb149f1-0a7e-454e-bb38-69f0de086ba2"
     }
-  ],
-  "vars": {
-    "DATA_SLOT": "a"
-  }
+  ]
 }


### PR DESCRIPTION
Course requests currently rebuild university-wide comparisons from 119,127 grade-history rows. Generate JSON during the GitHub build and have SSR, public JSON, and Markdown consume those same static documents. HTML and Markdown remain rendered on demand.

- Precompute course comparisons for pages and search badges; missing assets never fall back to scanning history.
- Include all course and historical instructor profiles. Group instructors into 4,096 assets to stay below the file limit.
- Replace A/B D1 with the requested single DB. D1 serves filtered search and paginated grade, review, and teaching queries.
- Reject uncached queries during imports (existing API responses can remain cached for 60 seconds); check a verified-import marker and matching projection before and after queries. Static pages remain available. Retry completed imports without importing again if Worker publication failed.
- Validate document schemas during generation and use the full dataset for CI browser checks.

Validation: 100 unit tests, 20 Python website tests, and Svelte check pass. The final production build has 70,877 assets (largest 6.4 MB), and all 63 browser tests passed. HTML, JSON, Markdown, navigation, department, and historical instructor pages were also verified against an empty D1. The final single-D1 build passed all 63 production browser tests. During a simulated import, static pages remained available and uncached search returned 503; the local database was then restored.

The Worker rollback alone does not restore D1 data. The new database is configured as DB; the old remote databases are not deleted.

Merge with a normal merge commit; do not squash.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added prebuilt document delivery for faster, consistent course, instructor, department, and explorer pages.
  * Added generated document assets with redirects, SEO metadata, and schema validation.
  * Added a JSON document endpoint for prerendered content.

* **Bug Fixes**
  * Pages now avoid serving inconsistent data during imports and return a maintenance response when content is unavailable.
  * Improved handling of aliases, encoded URLs, missing documents, and unavailable assets.

* **SEO**
  * Document endpoints are excluded from search indexing and require revalidation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->