### PR TITLE
fix(ci): test the production Worker with local D1

### DIFF
--- a/.github/workflows/svelte.yml
+++ b/.github/workflows/svelte.yml
@@ -51,6 +51,12 @@ jobs:
       - run: bun run seo:check
       - run: uv run --locked uwcourses-site assets-check
       - run: bun x playwright test
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: browser-failures-${{ github.job }}
+          path: test-results/
+          retention-days: 7
   deploy:
     name: Deploy
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -93,6 +99,12 @@ jobs:
       - run: bun run build
       - run: bun run seo:check
       - run: bun x playwright test
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: browser-failures-${{ github.job }}
+          path: test-results/
+          retention-days: 7
       - name: Deploy verified release
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/svelte.yml
+++ b/.github/workflows/svelte.yml
@@ -21,7 +21,7 @@ jobs:
       group: svelte-${{ github.ref }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,14 +1,16 @@
 import { defineConfig } from "@playwright/test";
+const preview = Boolean(process.env.TEST_PREVIEW || process.env.CI);
 const port = Number(process.env.TEST_PORT || 4173);
 const baseURL = `http://127.0.0.1:${port}`;
 export default defineConfig({
   testDir: "web/tests/browser",
   // Local workerd serves every browser from one process; avoid saturating it.
-  workers: process.env.TEST_PREVIEW ? 2 : undefined,
-  use: { baseURL },
+  workers: preview ? 2 : undefined,
+  globalSetup: preview ? "./web/tests/browser/setup.ts" : undefined,
+  use: { baseURL, trace: "retain-on-failure", screenshot: "only-on-failure" },
   webServer: {
-    command: process.env.TEST_PREVIEW
-      ? `bun run preview --ip 127.0.0.1 --port ${port}`
+    command: preview
+      ? `bun run preview --ip 127.0.0.1 --port ${port} --persist-to .site/browser-state`
       : `bun run dev --host 127.0.0.1 --port ${port}`,
     url: baseURL,
     reuseExistingServer: !process.env.CI,

--- a/web/tests/browser/course.spec.ts
+++ b/web/tests/browser/course.spec.ts
@@ -210,6 +210,7 @@ test("takeaways rotate and pause for reading sources", async ({ page }) => {
 });
 
 test("school and department comparisons stay synchronized", async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
   await page.goto("/courses/COMPSCI_300");
   await expect(page.locator("html")).toHaveAttribute("data-hydrated", "true");
   await page.getByRole("button", { name: "Term", exact: true }).click();

--- a/web/tests/browser/setup.ts
+++ b/web/tests/browser/setup.ts
@@ -23,22 +23,24 @@ export default async function setup() {
       await db.prepare(sql).run();
       const statement = source.prepare(`SELECT * FROM ${identifier(name)}`);
       statement.setReturnArrays(true);
-      let batch: D1PreparedStatement[] = [];
+      let rows: (string | number | null)[][] = [];
+      const flush = async () => {
+        if (!rows.length) return;
+        await db
+          .prepare(
+            `INSERT INTO ${identifier(name)} VALUES ${rows.map((row) => `(${row.map(() => "?").join(",")})`).join(",")}`,
+          )
+          .bind(...rows.flat())
+          .run();
+        rows = [];
+      };
       for (const row of statement.iterate()) {
         const values = row as unknown as (string | number | null)[];
-        batch.push(
-          db
-            .prepare(
-              `INSERT INTO ${identifier(name)} VALUES (${values.map(() => "?").join(",")})`,
-            )
-            .bind(...values),
-        );
-        if (batch.length === 100) {
-          await db.batch(batch);
-          batch = [];
-        }
+        // D1 permits at most 100 bound parameters per statement.
+        if ((rows.length + 1) * values.length > 100) await flush();
+        rows.push(values);
       }
-      if (batch.length) await db.batch(batch);
+      await flush();
     }
     for (const { sql } of source
       .prepare(

--- a/web/tests/browser/setup.ts
+++ b/web/tests/browser/setup.ts
@@ -1,37 +1,59 @@
-import { execFileSync } from "node:child_process";
-import { readdirSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
 import { randomUUID } from "node:crypto";
+import { getPlatformProxy } from "wrangler";
 
-/** Seed the production Worker's isolated local D1 before browser tests run. */
-export default function setup() {
-  const parts = readdirSync(".site/sql")
-    .filter((file) => file.endsWith(".sql"))
-    .sort();
-  if (!parts.length)
-    throw new Error("Run the dataset import before browser tests");
-  const execute = (...args: string[]) =>
-    execFileSync(
-      "bun",
-      [
-        "x",
-        "--no-install",
-        "wrangler",
-        "d1",
-        "execute",
-        "DB",
-        "--local",
-        "--persist-to",
-        ".site/browser-state",
-        ...args,
-      ],
-      { stdio: ["ignore", "ignore", "inherit"] },
-    );
-  for (const part of parts) {
-    console.log(`Seeding browser D1: ${part}`);
-    execute("--file", `.site/sql/${part}`);
+/** Copy the full dataset into an isolated local D1, using bounded API batches. */
+export default async function setup() {
+  const source = new DatabaseSync(".site/site.sqlite", { readOnly: true });
+  const platform = await getPlatformProxy<{ DB: D1Database }>({
+    remoteBindings: false,
+    persist: { path: ".site/browser-state/v3" },
+  });
+  const db = platform.env.DB;
+  const tables = source
+    .prepare(
+      "SELECT name,sql FROM sqlite_master WHERE type='table' AND (name NOT LIKE 'search%' OR name='search') AND name NOT LIKE 'sqlite_%'",
+    )
+    .all() as { name: string; sql: string }[];
+  const identifier = (name: string) => '"' + name.replaceAll('"', '""') + '"';
+  try {
+    for (const { name, sql } of tables) {
+      console.log(`Seeding browser D1: ${name}`);
+      await db.prepare(`DROP TABLE IF EXISTS ${identifier(name)}`).run();
+      await db.prepare(sql).run();
+      const statement = source.prepare(`SELECT * FROM ${identifier(name)}`);
+      statement.setReturnArrays(true);
+      let batch: D1PreparedStatement[] = [];
+      for (const row of statement.iterate()) {
+        const values = row as unknown as (string | number | null)[];
+        batch.push(
+          db
+            .prepare(
+              `INSERT INTO ${identifier(name)} VALUES (${values.map(() => "?").join(",")})`,
+            )
+            .bind(...values),
+        );
+        if (batch.length === 100) {
+          await db.batch(batch);
+          batch = [];
+        }
+      }
+      if (batch.length) await db.batch(batch);
+    }
+    for (const { sql } of source
+      .prepare(
+        "SELECT sql FROM sqlite_master WHERE type='index' AND sql IS NOT NULL AND name NOT LIKE 'search%'",
+      )
+      .all())
+      await db.prepare(String(sql)).run();
+    await db.batch([
+      db.prepare("INSERT OR REPLACE INTO metadata VALUES ('ready', 'true')"),
+      db
+        .prepare("INSERT OR REPLACE INTO metadata VALUES ('serving', ?)")
+        .bind(randomUUID().replaceAll("-", "")),
+    ]);
+  } finally {
+    source.close();
+    await platform.dispose();
   }
-  execute(
-    "--command",
-    `INSERT OR REPLACE INTO metadata VALUES ('serving', '${randomUUID().replaceAll("-", "")}')`,
-  );
 }

--- a/web/tests/browser/setup.ts
+++ b/web/tests/browser/setup.ts
@@ -1,0 +1,37 @@
+import { execFileSync } from "node:child_process";
+import { readdirSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+
+/** Seed the production Worker's isolated local D1 before browser tests run. */
+export default function setup() {
+  const parts = readdirSync(".site/sql")
+    .filter((file) => file.endsWith(".sql"))
+    .sort();
+  if (!parts.length)
+    throw new Error("Run the dataset import before browser tests");
+  const execute = (...args: string[]) =>
+    execFileSync(
+      "bun",
+      [
+        "x",
+        "--no-install",
+        "wrangler",
+        "d1",
+        "execute",
+        "DB",
+        "--local",
+        "--persist-to",
+        ".site/browser-state",
+        ...args,
+      ],
+      { stdio: "pipe", maxBuffer: 16 * 1024 * 1024 },
+    );
+  for (const part of parts) {
+    console.log(`Seeding browser D1: ${part}`);
+    execute("--file", `.site/sql/${part}`);
+  }
+  execute(
+    "--command",
+    `INSERT OR REPLACE INTO metadata VALUES ('serving', '${randomUUID().replaceAll("-", "")}')`,
+  );
+}

--- a/web/tests/browser/setup.ts
+++ b/web/tests/browser/setup.ts
@@ -24,7 +24,7 @@ export default function setup() {
         ".site/browser-state",
         ...args,
       ],
-      { stdio: "pipe", maxBuffer: 16 * 1024 * 1024 },
+      { stdio: ["ignore", "ignore", "inherit"] },
     );
   for (const part of parts) {
     console.log(`Seeding browser D1: ${part}`);


### PR DESCRIPTION
CI previously built production assets but ran browser checks against Vite development mode. It now tests the built Worker with a complete, isolated local D1 populated through Wrangler's local API. Multi-row inserts stay within D1's parameter limit. Failed browser runs retain screenshots and traces.

A retained trace also identified a tooltip hover racing smooth scrolling after term selection. That comparison test now uses reduced motion; hydration timeouts and separate motion tests remain unchanged.

Validation: Svelte check passes with zero errors or warnings; full local D1 fixture loaded successfully; all 63 production browser tests passed; the comparison test passed 10 consecutive runs. Final suite reused the completed fixture to avoid repeating the import.

Merge with a normal merge commit. Deployment remains manual or nightly and repeats production validation before publication.
