### PR TITLE
fix(deploy): capture D1 readiness query JSON

### DIFF
--- a/web/tests/test_deployment.py
+++ b/web/tests/test_deployment.py
@@ -119,6 +119,32 @@ class DeploymentTests(unittest.TestCase):
         self.run_deploy(missing=True)
         self.run_deploy(missing=True, first=True)
 
+    def test_readiness_queries_capture_json_from_the_subprocess(self):
+        for tables in (0, 2):
+            with self.subTest(tables=tables):
+                outputs = iter(
+                    [
+                        json.dumps(
+                            [{"results": [{"tables": tables}], "success": True}]
+                        ),
+                        self.report(),
+                    ]
+                )
+
+                def run(args, **kwargs):
+                    self.assertIn("--json", args)
+                    self.assertIs(kwargs.get("stdout"), subprocess.PIPE)
+                    return subprocess.CompletedProcess(args, 0, stdout=next(outputs))
+
+                with patch(
+                    "uwcourses_site.deployment.subprocess.run", side_effect=run
+                ) as command:
+                    self.assertEqual(
+                        database_matches(Path("wrangler.json"), self.release),
+                        tables == 2,
+                    )
+                    self.assertEqual(command.call_count, 1 if tables == 0 else 2)
+
     @patch("uwcourses_site.deployment.wrangler")
     def test_database_readiness_controls_reuse_after_failed_publication(self, command):
         tables = json.dumps([{"results": [{"tables": 2}], "success": True}])

--- a/web/uwcourses_site/deployment.py
+++ b/web/uwcourses_site/deployment.py
@@ -173,6 +173,7 @@ def database_matches(config: Path, release: Release) -> bool:
         "--json",
         "--command",
         "SELECT count(*) tables FROM sqlite_master WHERE type='table' AND name IN ('metadata','courses')",
+        capture=True,
     )
     if json.loads(output)[0]["results"][0]["tables"] != 2:
         return False
@@ -187,6 +188,7 @@ def database_matches(config: Path, release: Release) -> bool:
         "SELECT (SELECT value FROM metadata WHERE key='ready') ready, "
         "(SELECT value FROM metadata WHERE key='status') status, "
         "(SELECT count(*) FROM courses) courses",
+        capture=True,
     )
     try:
         verify_database(output, release)


### PR DESCRIPTION
D1 readiness queries printed JSON to the workflow log without capturing stdout, then attempted to parse an empty string. Capture both the table-existence and release-readiness query outputs.

Validation: regression test fails before the fix and passes after it; all 21 Python website tests and Ruff pass. Real local Wrangler checks correctly reject an empty D1 and reuse the complete matching fixture. Existing production browser checks passed in the failed deployment run.

Normal merge; do not squash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deployment database checks to accurately interpret inspection results.
  - Deployment readiness is now correctly reported when databases are empty or contain tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->